### PR TITLE
Fix for sending private url

### DIFF
--- a/workers/loc.api/queue/views/email.pug
+++ b/workers/loc.api/queue/views/email.pug
@@ -39,7 +39,7 @@ div(style='border-collapse: collapse;margin: 0;padding: 0;background-color: #d4d
                     tbody
                       tr
                         td
-                          a(href=public_url, target='_blank', style='background-color: #3498db;border: solid 1px #3498db;border-radius: 5px;box-sizing: border-box;color: #ffffff;cursor: pointer;display: inline-block;font-size: 14px;font-weight: bold;margin-top: 30px;margin-bottom:20px;padding: 12px 25px;text-decoration: none;text-transform: capitalize;') Download CSV
+                          a(href=presigned_url, target='_blank', style='background-color: #3498db;border: solid 1px #3498db;border-radius: 5px;box-sizing: border-box;color: #ffffff;cursor: pointer;display: inline-block;font-size: 14px;font-weight: bold;margin-top: 30px;margin-bottom:20px;padding: 12px 25px;text-decoration: none;text-transform: capitalize;') Download CSV
               tr
                 td(align='left')
                   div(style='font-size: 13px;line-height: 150%;color:#999;padding:9px 0;')


### PR DESCRIPTION
When template was updated, was updated with public_url instead of presigned_url