### PR TITLE
Add presigned url to plain text emails

### DIFF
--- a/workers/loc.api/queue/helpers.js
+++ b/workers/loc.api/queue/helpers.js
@@ -523,7 +523,7 @@ const uploadS3 = async (
 
 const sendMail = (reportService, configs, to, viewName, data) => {
   const grcBfx = reportService.ctx.grc_bfx
-  const text = `Download (${data.fileName}): ${data.public_url}`
+  const text = `Download (${data.fileName}): ${data.presigned_url}`
   const html = pug.renderFile(
     path.join(basePathToViews, viewName),
     data


### PR DESCRIPTION
Fix as to send presigned url on plain text emails