### PR TITLE
Remove ability to redirect requests for wallets

### DIFF
--- a/workers/loc.api/service.report.mediator.js
+++ b/workers/loc.api/service.report.mediator.js
@@ -491,28 +491,6 @@ class MediatorReportService extends ReportService {
   }
 
   /**
-   * TODO: need to implement sync mode
-   * @override
-   */
-  async getWallets (space, args, cb) {
-    try {
-      if (!await this.isSyncModeWithDbData(space, args)) {
-        super.getWallets(space, args, cb)
-
-        return
-      }
-
-      checkParams(args, 'paramsSchemaForWallets')
-
-      const res = await this._getWallets(args)
-
-      cb(null, res)
-    } catch (err) {
-      cb(err)
-    }
-  }
-
-  /**
    * @override
    */
   async getLedgers (space, args, cb) {
@@ -742,10 +720,6 @@ class MediatorReportService extends ReportService {
 
   _getTickersHistory (args) {
     return promisify(super.getTickersHistory.bind(this))(null, args)
-  }
-
-  _getWallets (args) {
-    return promisify(super.getWallets.bind(this))(null, args)
   }
 
   _getPositionsHistory (args) {


### PR DESCRIPTION
Ability to sync wallet and wallet history was removed as there was too much data to sync with an endpoint that returns few changes on each call resulting in a quite slow user experience.