### PR TITLE
Refactor isRateLimitError function

### DIFF
--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -275,7 +275,7 @@ const isEaiAgainError = (err) => {
 }
 
 const isRateLimitError = (err) => {
-  return /ERR_RATE_LIMIT/.test(err.toString())
+  return /ERR(_RATE)?_LIMIT/.test(err.toString())
 }
 
 const isNonceSmallError = (err) => {

--- a/workers/loc.api/queue/helpers.js
+++ b/workers/loc.api/queue/helpers.js
@@ -22,7 +22,7 @@ const basePathToViews = path.join(__dirname, 'views')
 const isElectronjsEnv = argv.isElectronjsEnv
 
 const isRateLimitError = (err) => {
-  return /ERR_RATE_LIMIT/.test(err.toString())
+  return /ERR(_RATE)?_LIMIT/.test(err.toString())
 }
 
 const isNonceSmallError = (err) => {


### PR DESCRIPTION
This adds support for error handling of `ERR_RATE_LIMIT` and `ERR_RATE` since `api_v2` can return both