### PR TITLE
Remove ability to redirect requests for positionsAudit in sync mode

### DIFF
--- a/test/2-sync-mode-sqlite.spec.js
+++ b/test/2-sync-mode-sqlite.spec.js
@@ -806,7 +806,7 @@ describe('Sync mode with SQLite', () => {
     assert.propertyVal(res.body, 'id', 5)
     assert.isObject(res.body.result)
     assert.isArray(res.body.result.res)
-    assert.isBoolean(res.body.result.nextPage) // TODO: This will be changed to isNumber when implemented in sync mode
+    assert.isBoolean(res.body.result.nextPage)
 
     const resItem = res.body.result.res[0]
 

--- a/workers/loc.api/service.report.mediator.js
+++ b/workers/loc.api/service.report.mediator.js
@@ -469,28 +469,6 @@ class MediatorReportService extends ReportService {
   }
 
   /**
-   * TODO: need to implement sync mode
-   * @override
-   */
-  async getPositionsAudit (space, args, cb) {
-    try {
-      if (!await this.isSyncModeWithDbData(space, args)) {
-        super.getPositionsAudit(space, args, cb)
-
-        return
-      }
-
-      checkParams(args, 'paramsSchemaForPositionsAudit')
-
-      const res = await this._getPositionsAudit(args)
-
-      cb(null, res)
-    } catch (err) {
-      cb(err)
-    }
-  }
-
-  /**
    * @override
    */
   async getLedgers (space, args, cb) {
@@ -724,10 +702,6 @@ class MediatorReportService extends ReportService {
 
   _getPositionsHistory (args) {
     return promisify(super.getPositionsHistory.bind(this))(null, args)
-  }
-
-  _getPositionsAudit (args) {
-    return promisify(super.getPositionsAudit.bind(this))(null, args)
   }
 
   _getLedgers (args) {


### PR DESCRIPTION
Due to the fact that was decided not to implement synchronization of positionsAudit, removed the ability to redirect requests for positionsAudit in the sync mode