### PR TITLE
Add ability to filter ledgers starting with "Margin Funding Payment" in description field

### DIFF
--- a/workers/loc.api/sync/dao/dao.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.sqlite.js
@@ -68,7 +68,14 @@ class SqliteDAO extends DAO {
   _deserializeVal (
     val,
     key,
-    boolFields = ['notify', 'hidden', 'renew', 'noClose', 'maker']
+    boolFields = [
+      'notify',
+      'hidden',
+      'renew',
+      'noClose',
+      'maker',
+      '_isMarginFundingPayment'
+    ]
   ) {
     if (
       typeof val === 'string' &&
@@ -433,6 +440,12 @@ class SqliteDAO extends DAO {
       filter.start = params.start ? params.start : 0
       filter.end = params.end ? params.end : (new Date()).getTime()
 
+      if (
+        typeof params.isMarginFundingPayment === 'boolean' &&
+        Object.keys(methodColl.model).some(key => key === '_isMarginFundingPayment')
+      ) {
+        filter._isMarginFundingPayment = Number(params.isMarginFundingPayment)
+      }
       if (params.symbol) {
         if (typeof params.symbol === 'string') {
           filter[methodColl.symbolFieldName] = params.symbol

--- a/workers/loc.api/sync/data.inserter.js
+++ b/workers/loc.api/sync/data.inserter.js
@@ -668,6 +668,11 @@ class DataInserter extends EventEmitter {
           ) {
             itemRes._symbol = args.params.symbol
           }
+          if (collName === ALLOWED_COLLS.LEDGERS) {
+            itemRes._isMarginFundingPayment = this._isMarginFundingPayment(
+              itemRes.description
+            )
+          }
         })
       )
 
@@ -687,6 +692,10 @@ class DataInserter extends EventEmitter {
         currIterationArgs.params.end = lastItem[dateFieldName] - 1
       }
     }
+  }
+
+  _isMarginFundingPayment (str) {
+    return /Margin Funding Payment/gi.test(str)
   }
 
   async _updateApiDataArrTypeToDb (

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -29,6 +29,7 @@ const _models = new Map([
       balance: 'DECIMAL(22,12)',
       description: 'TEXT',
       wallet: 'VARCHAR(255)',
+      _isMarginFundingPayment: 'INT',
       user_id: `INT NOT NULL,
         CONSTRAINT ledgers_fk_#{field}
         FOREIGN KEY (#{field})


### PR DESCRIPTION
Funding earnings is an old report feature that was available before. There is no `api` endpoint for this.
This PR adds the ability to generate the report by filtering the ledgers starting with `Margin Funding Payment` in the description field for users using sync mode only. It adds `_isMarginFundingPayment` field to DB as to do searches faster

Examples:
  - get ledgers starting with `Margin Funding Payment` in the description field
```
{
    "auth": {
        "apiKey": "fake",
        "apiSecret": "fake"
    },
    "method": "getLedgers", // or getLedgersCsv
    "params": {
    	"symbol": "BTC",
    	"isMarginFundingPayment": true
    }
}
```
  - get ledgers starting without `Margin Funding Payment` in the description field
```
{
    "auth": {
        "apiKey": "fake",
        "apiSecret": "fake"
    },
    "method": "getLedgers", // or getLedgersCsv
    "params": {
    	"symbol": "BTC",
    	"isMarginFundingPayment": false
    }
}
```
  - data is not filtered if the `isMarginFundingPayment` parameter will not be passed