### PR TITLE
Throw DuringSyncMethodAccessError error in getLedgers method if isMarginFundingPayment: true

### DIFF
--- a/workers/loc.api/service.report.mediator.js
+++ b/workers/loc.api/service.report.mediator.js
@@ -28,7 +28,8 @@ const sync = require('./sync')
 const {
   AuthError,
   DAOInitializationError,
-  ServerAvailabilityError
+  ServerAvailabilityError,
+  DuringSyncMethodAccessError
 } = require('./errors')
 
 class MediatorReportService extends ReportService {
@@ -489,6 +490,12 @@ class MediatorReportService extends ReportService {
   async getLedgers (space, args, cb) {
     try {
       if (!await this.isSyncModeWithDbData(space, args)) {
+        const { isMarginFundingPayment } = { ...args.params }
+
+        if (isMarginFundingPayment) {
+          throw new DuringSyncMethodAccessError()
+        }
+
         super.getLedgers(space, args, cb)
 
         return


### PR DESCRIPTION
This PR adds an ability to throw `DuringSyncMethodAccessError` error when `getLedgers()` method is called with `isMarginFundingPayment: true` param if sync is not completed