### PR TITLE
Fix getWallets async response return

### DIFF
--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -5,7 +5,7 @@ const _ms = Date.now()
 module.exports = new Map([
   [
     'symbols',
-    [
+    [[
       'btcusd',
       'ethusd',
       'ethbtc',
@@ -17,7 +17,7 @@ module.exports = new Map([
       'ifxusd',
       'ioteur',
       'euxusx'
-    ]
+    ]]
   ],
   [
     'user_info',

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -218,11 +218,12 @@ class ReportService extends Api {
       const rest = getREST(args.auth, this.ctx.grc_bfx.caller)
       const end = args.params && args.params.end
 
-      const result = (end)
+      const res = (end)
         ? await rest.walletsHistory(end)
         : await rest.wallets()
 
-      cb(null, result)
+      if (!cb) return res
+      cb(null, res)
     } catch (err) {
       this._err(err, 'getWallet', cb)
     }

--- a/workers/loc.api/service.report.mediator.js
+++ b/workers/loc.api/service.report.mediator.js
@@ -724,9 +724,7 @@ class MediatorReportService extends ReportService {
   async getWallets (space, args, cb) {
     try {
       if (!await this.isSyncModeWithDbData(space, args)) {
-        super.getWallets(space, args, cb)
-
-        return
+        return super.getWallets(space, args, cb)
       }
 
       checkParams(args, 'paramsSchemaForWallets')
@@ -763,9 +761,9 @@ class MediatorReportService extends ReportService {
           date.getUTCMilliseconds() === 0
         )
       ) {
-        cb(null, wallets)
+        if (!cb) return wallets
 
-        return
+        return cb(null, wallets)
       }
 
       const ledgersArgs = {
@@ -784,9 +782,9 @@ class MediatorReportService extends ReportService {
         !Array.isArray(ledgers) ||
         ledgers.length === 0
       ) {
-        cb(null, wallets)
+        if (!cb) return wallets
 
-        return
+        return cb(null, wallets)
       }
 
       const res = wallets.map(wallet => {


### PR DESCRIPTION
This PR fixes async response return of the `getWallets` method
And small fixes mock data of the symbols, it is related to this changing [bfx-api-node-rest](https://github.com/bitfinexcom/bfx-api-node-rest/pull/24/commits/bd80067e7a98b1678f47585771667e1b28f98bb2), and depends on this PR [bfx-api-mock-srv](https://github.com/bitfinexcom/bfx-api-mock-srv/pull/17)