### PR TITLE
Fix currencies sync

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -206,6 +206,7 @@ describe('API', () => {
     assert.isArray(res.body.result.pairs)
     assert.isArray(res.body.result.currencies)
     assert.lengthOf(res.body.result.pairs, 11)
+    assert.lengthOf(res.body.result.currencies, 11)
 
     res.body.result.pairs.forEach(item => {
       assert.isString(item)

--- a/test/2-sync-mode-sqlite.spec.js
+++ b/test/2-sync-mode-sqlite.spec.js
@@ -694,6 +694,7 @@ describe('Sync mode with SQLite', () => {
     assert.isArray(res.body.result.pairs)
     assert.isArray(res.body.result.currencies)
     assert.lengthOf(res.body.result.pairs, 11)
+    assert.lengthOf(res.body.result.currencies, 11)
 
     res.body.result.pairs.forEach(item => {
       assert.isString(item)

--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -169,7 +169,10 @@ const createMockRESTv2SrvWithDate = (
     const data = Array(_limit).fill(null).map((item, i) => {
       if (_limit === (i + mockData.length)) {
         date = end
-      } else if (i + 1 > mockData.length) {
+      } else if (
+        i + 1 > mockData.length &&
+        i % mockData.length === 0
+      ) {
         date += step
       }
       if (i > 0) {

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -311,11 +311,59 @@ module.exports = new Map([
   [
     'currencies',
     [
-      ['USD', 'US Dollar'],
-      ['BTC', 'Bitcoin'],
-      ['LTC', 'Litecoin'],
-      ['DSH', 'Dash'],
-      ['ETH', 'Ethereum']
+      [
+        'BTC',
+        'ETH',
+        'EUR',
+        'EUT',
+        'GRG',
+        'IOT',
+        'MLN',
+        'REP',
+        'USD',
+        'UST',
+        'ZRX'
+      ],
+      [
+        ['EUT', 'EURt'],
+        ['GRG', 'WWWWWW'],
+        ['IOT', 'IOTA'],
+        ['UST', 'USDt']
+      ],
+      [
+        ['BTC', 'Bitcoin'],
+        ['ETH', 'Ethereum'],
+        ['EUR', 'Euro'],
+        ['GRG', 'RigoBlock'],
+        ['IOT', 'IOTA'],
+        ['MLN', 'Melonport'],
+        ['USD', 'US Dollar'],
+        ['ZRX', '0x']
+      ],
+      [
+        ['REP', 'ETH'],
+        ['GRG', 'ETH'],
+        ['ZRX', 'ETH'],
+        ['MLN', 'ETH']
+      ],
+      [
+        [
+          'BTC',
+          [
+            'https://blockstream.info',
+            'https://blockstream.info/address/VAL',
+            'https://blockstream.info/tx/VAL'
+          ]
+        ],
+        [
+          'ETH',
+          [
+            'https://etherscan.io',
+            'https://etherscan.io/address/VAL',
+            'https://etherscan.io/tx/VAL'
+          ]
+        ]
+      ]
     ]
   ]
 ])

--- a/workers/loc.api/sync/dao/dao.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.sqlite.js
@@ -19,7 +19,8 @@ const {
   getUniqueIndexQuery,
   getInsertableArrayObjectsFilter,
   getProjectionQuery,
-  getPlaceholdersQuery
+  getPlaceholdersQuery,
+  serializeVal
 } = require('./helpers')
 const {
   AuthError,
@@ -238,15 +239,19 @@ class SqliteDAO extends DAO {
           continue
         }
 
+        const _obj = keys.reduce((accum, key) => ({
+          ...accum,
+          [key]: serializeVal(obj[key])
+        }), {})
         const projection = getProjectionQuery(keys)
         const {
           where,
           values
-        } = getWhereQuery(obj)
+        } = getWhereQuery(_obj)
         const {
           placeholders,
           placeholderVal
-        } = getPlaceholdersQuery(obj, keys)
+        } = getPlaceholdersQuery(_obj, keys)
 
         const sql = `INSERT INTO ${name}(${projection}) SELECT ${placeholders}
                       WHERE NOT EXISTS(SELECT 1 FROM ${name} ${where})`

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -526,6 +526,7 @@ const _methodCollMap = new Map([
       sort: [['name', 1]],
       hasNewData: true,
       type: 'public:updatable:array:objects',
+      fieldsOfUniqueIndex: ['id', 'name', 'pool', 'explorer'],
       model: { ..._models.get(ALLOWED_COLLS.CURRENCIES) }
     }
   ]


### PR DESCRIPTION
This PR fixes currencies sync. The issue is related: when the next sync is done then currencies will be added into DB as new rows. In this case, should refresh rows or `add`/`remove` if `not exist in the DB`/`not exist from API`. **Depends** on this PR [bfx-api-mock-srv#18](https://github.com/bitfinexcom/bfx-api-mock-srv/pull/18)