### PR TITLE
Add active orders report

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -960,6 +960,50 @@ describe('API', () => {
     ])
   })
 
+  it('it should be successfully performed by the getActiveOrders method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getActiveOrders',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isArray(res.body.result)
+
+    const resItem = res.body.result[0]
+
+    assert.isObject(resItem)
+    assert.containsAllKeys(resItem, [
+      'id',
+      'gid',
+      'cid',
+      'symbol',
+      'mtsCreate',
+      'mtsUpdate',
+      'amount',
+      'amountOrig',
+      'type',
+      'typePrev',
+      'flags',
+      'status',
+      'price',
+      'priceAvg',
+      'priceTrailing',
+      'priceAuxLimit',
+      'notify',
+      'placedId',
+      'amountExecuted'
+    ])
+  })
+
   it('it should be successfully performed by the getMovements method', async function () {
     this.timeout(5000)
 

--- a/test/2-sync-mode-sqlite.spec.js
+++ b/test/2-sync-mode-sqlite.spec.js
@@ -1413,6 +1413,50 @@ describe('Sync mode with SQLite', () => {
     ])
   })
 
+  it('it should be successfully performed by the getActiveOrders method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getActiveOrders',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isArray(res.body.result)
+
+    const resItem = res.body.result[0]
+
+    assert.isObject(resItem)
+    assert.containsAllKeys(resItem, [
+      'id',
+      'gid',
+      'cid',
+      'symbol',
+      'mtsCreate',
+      'mtsUpdate',
+      'amount',
+      'amountOrig',
+      'type',
+      'typePrev',
+      'flags',
+      'status',
+      'price',
+      'priceAvg',
+      'priceTrailing',
+      'priceAuxLimit',
+      'notify',
+      'placedId',
+      'amountExecuted'
+    ])
+  })
+
   it('it should be successfully performed by the getMovements method', async function () {
     this.timeout(5000)
 
@@ -1980,6 +2024,29 @@ describe('Sync mode with SQLite', () => {
           symbol: 'tBTCUSD',
           end,
           start,
+          email
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+  })
+
+  it('it should be successfully performed by the getActiveOrdersCsv method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getActiveOrdersCsv',
+        params: {
           email
         },
         id: 5

--- a/test/3-queue-base.spec.js
+++ b/test/3-queue-base.spec.js
@@ -523,6 +523,29 @@ describe('Queue', () => {
     await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
+  it('it should be successfully performed by the getActiveOrdersCsv method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getActiveOrdersCsv',
+        params: {
+          email
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+  })
+
   it('it should be successfully performed by the getMovementsCsv method', async function () {
     this.timeout(3 * 60000)
 

--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -88,6 +88,12 @@ const setDataTo = (
       dataItem[5] = _date
       break
 
+    case 'active_orders':
+      dataItem[0] = id
+      dataItem[4] = _date
+      dataItem[5] = _date
+      break
+
     case 'movements':
       dataItem[0] = id
       dataItem[5] = _date
@@ -127,6 +133,7 @@ const getMockDataOpts = () => ({
   trades: { limit: 1000 },
   public_trades: { limit: 5000 },
   orders: { limit: 500 },
+  active_orders: { limit: 100 },
   movements: { limit: 25 },
   f_offer_hist: { limit: 500 },
   f_loan_hist: { limit: 500 },

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -203,6 +203,37 @@ module.exports = new Map([
     ]]
   ],
   [
+    'active_orders',
+    [[
+      12345,
+      12345,
+      12345,
+      'tBTCUSD',
+      _ms,
+      _ms,
+      0,
+      0.01,
+      'EXCHANGE LIMIT',
+      null,
+      null,
+      null,
+      '0',
+      'EXECUTED @ 15065.0(0.01)',
+      null,
+      null,
+      12345,
+      12345,
+      12345,
+      12345,
+      null,
+      null,
+      null,
+      false,
+      null,
+      null
+    ]]
+  ],
+  [
     'movements',
     [[
       12345,

--- a/workers/loc.api/helpers/get-csv-job-data.js
+++ b/workers/loc.api/helpers/get-csv-job-data.js
@@ -445,6 +445,53 @@ const getCsvJobData = {
 
     return jobData
   },
+  async getActiveOrdersCsvJobData (
+    reportService,
+    args,
+    uId,
+    uInfo
+  ) {
+    checkParams(args)
+
+    const {
+      userId,
+      userInfo
+    } = await checkJobAndGetUserData(
+      reportService,
+      args,
+      uId,
+      uInfo
+    )
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getActiveOrders',
+      args,
+      propNameForPagination: null,
+      columnsCsv: {
+        id: '#',
+        symbol: 'PAIR',
+        type: 'TYPE',
+        typePrev: 'PREVIOUS ORDER TYPE',
+        amountOrig: 'AMOUNT',
+        amountExecuted: 'EXECUTED AMOUNT',
+        price: 'PRICE',
+        priceAvg: 'AVERAGE EXECUTION PRICE',
+        priceTrailing: 'TRAILING PRICE',
+        mtsCreate: 'CREATED',
+        mtsUpdate: 'UPDATED',
+        status: 'STATUS'
+      },
+      formatSettings: {
+        mtsUpdate: 'date',
+        mtsCreate: 'date',
+        symbol: 'symbol'
+      }
+    }
+
+    return jobData
+  },
   async getMovementsCsvJobData (
     reportService,
     args,

--- a/workers/loc.api/helpers/get-csv-job-data.js
+++ b/workers/loc.api/helpers/get-csv-job-data.js
@@ -428,10 +428,12 @@ const getCsvJobData = {
         id: '#',
         symbol: 'PAIR',
         type: 'TYPE',
+        typePrev: 'PREVIOUS ORDER TYPE',
         amountOrig: 'AMOUNT',
         amountExecuted: 'EXECUTED AMOUNT',
         price: 'PRICE',
         priceAvg: 'AVERAGE EXECUTION PRICE',
+        priceTrailing: 'TRAILING PRICE',
         mtsCreate: 'CREATED',
         mtsUpdate: 'UPDATED',
         status: 'STATUS'

--- a/workers/loc.api/queue/helpers.js
+++ b/workers/loc.api/queue/helpers.js
@@ -483,7 +483,7 @@ const _getBaseName = (
 
   return namesMap.has(queueName)
     ? namesMap.get(queueName)
-    : _.snakeCase(queueName)
+    : _.snakeCase(queueName.replace(/^get/, ''))
 }
 
 const _getCompleteFileName = (

--- a/workers/loc.api/queue/helpers.js
+++ b/workers/loc.api/queue/helpers.js
@@ -426,6 +426,7 @@ const _fileNamesMap = new Map([
   ['getPublicFunding', 'public_funding'],
   ['getLedgers', 'ledgers'],
   ['getOrders', 'orders'],
+  ['getActiveOrders', 'active_orders'],
   ['getMovements', 'movements'],
   ['getFundingOfferHistory', 'funding_offers_history'],
   ['getFundingLoanHistory', 'funding_loans_history'],

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -296,6 +296,19 @@ class ReportService extends Api {
     }
   }
 
+  async getActiveOrders (space, args, cb) {
+    try {
+      const rest = getREST(args.auth, this.ctx.grc_bfx.caller)
+
+      const _res = await rest.activeOrders()
+      const res = parseFields(_res, { executed: true })
+
+      cb(null, res)
+    } catch (err) {
+      this._err(err, 'getActiveOrders', cb)
+    }
+  }
+
   async getMovements (space, args, cb) {
     try {
       const res = await prepareApiResponse(

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -22,6 +22,7 @@ const {
   getPublicTradesCsvJobData,
   getLedgersCsvJobData,
   getOrdersCsvJobData,
+  getActiveOrdersCsvJobData,
   getMovementsCsvJobData,
   getFundingOfferHistoryCsvJobData,
   getFundingLoanHistoryCsvJobData,
@@ -513,6 +514,20 @@ class ReportService extends Api {
       cb(null, status)
     } catch (err) {
       this._err(err, 'getOrdersCsv', cb)
+    }
+  }
+
+  async getActiveOrdersCsv (space, args, cb) {
+    try {
+      const status = await getCsvStoreStatus(this, args)
+      const jobData = await getActiveOrdersCsvJobData(this, args)
+      const processorQueue = this.ctx.lokue_processor.q
+
+      processorQueue.addJob(jobData)
+
+      cb(null, status)
+    } catch (err) {
+      this._err(err, 'getActiveOrdersCsv', cb)
     }
   }
 


### PR DESCRIPTION
This PR adds the [active orders](https://docs.bitfinex.com/v2/reference#rest-auth-orders) report without sync. Base changes:
  - adds `getActiveOrders` method
  - adds `getActiveOrdersCsv` method
  - adds `typePrev` and `priceTrailing` fields to `getOrdersCsv` method
  - improves tests coverage