### PR TITLE
Add funding trades report

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -811,6 +811,47 @@ describe('API', () => {
     ])
   })
 
+  it('it should be successfully performed by the getFundingTrades method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getFundingTrades',
+        params: {
+          symbol: 'fBTC',
+          start: 0,
+          end,
+          limit: 2
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isArray(res.body.result.res)
+    assert.isNumber(res.body.result.nextPage)
+
+    const resItem = res.body.result.res[0]
+
+    assert.isObject(resItem)
+    assert.containsAllKeys(resItem, [
+      'id',
+      'symbol',
+      'mtsCreate',
+      'offerID',
+      'amount',
+      'rate',
+      'period',
+      'maker'
+    ])
+  })
+
   it('it should be successfully performed by the getPublicTrades method', async function () {
     this.timeout(5000)
 

--- a/test/2-sync-mode-sqlite.spec.js
+++ b/test/2-sync-mode-sqlite.spec.js
@@ -1261,6 +1261,47 @@ describe('Sync mode with SQLite', () => {
     ])
   })
 
+  it('it should be successfully performed by the getFundingTrades method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getFundingTrades',
+        params: {
+          symbol: 'fBTC',
+          start: 0,
+          end,
+          limit: 2
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isArray(res.body.result.res)
+    assert.isNumber(res.body.result.nextPage)
+
+    const resItem = res.body.result.res[0]
+
+    assert.isObject(resItem)
+    assert.containsAllKeys(resItem, [
+      'id',
+      'symbol',
+      'mtsCreate',
+      'offerID',
+      'amount',
+      'rate',
+      'period',
+      'maker'
+    ])
+  })
+
   it('it should be successfully performed by the getPublicTrades method', async function () {
     this.timeout(5000)
 
@@ -1910,6 +1951,33 @@ describe('Sync mode with SQLite', () => {
         method: 'getTradesCsv',
         params: {
           symbol: ['tBTCUSD', 'tETHUSD'],
+          end,
+          start,
+          limit: 1000,
+          email
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+  })
+
+  it('it should be successfully performed by the getFundingTradesCsv method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getFundingTradesCsv',
+        params: {
+          symbol: ['fBTC', 'fETH'],
           end,
           start,
           limit: 1000,

--- a/test/3-queue-base.spec.js
+++ b/test/3-queue-base.spec.js
@@ -410,6 +410,34 @@ describe('Queue', () => {
     await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
+  it('it should be successfully performed by the getFundingTradesCsv method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getFundingTradesCsv',
+        params: {
+          symbol: ['fBTC'],
+          end,
+          start,
+          limit: 1000,
+          timezone: 'America/Los_Angeles',
+          email
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+  })
+
   it('it should be successfully performed by the getPublicTradesCsv method', async function () {
     this.timeout(60000)
 

--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -77,6 +77,12 @@ const setDataTo = (
       dataItem[9] = fee
       break
 
+    case 'f_trade_hist':
+      dataItem[0] = id
+      dataItem[2] = _date
+      dataItem[3] = id
+      break
+
     case 'public_trades':
       dataItem[0] = id
       dataItem[1] = _date
@@ -131,6 +137,7 @@ const getMockDataOpts = () => ({
   positions_audit: { limit: 250 },
   ledgers: { limit: 500 },
   trades: { limit: 1000 },
+  f_trade_hist: { limit: 1000 },
   public_trades: { limit: 5000 },
   orders: { limit: 500 },
   active_orders: { limit: 100 },

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -172,6 +172,19 @@ module.exports = new Map([
     ]]
   ],
   [
+    'f_trade_hist',
+    [[
+      12345,
+      'fBTC',
+      _ms,
+      12345,
+      12345.12345,
+      0.003,
+      30,
+      null
+    ]]
+  ],
+  [
     'orders',
     [[
       12345,

--- a/workers/loc.api/helpers/get-csv-job-data.js
+++ b/workers/loc.api/helpers/get-csv-job-data.js
@@ -58,6 +58,50 @@ const getCsvJobData = {
 
     return jobData
   },
+  async getFundingTradesCsvJobData (
+    reportService,
+    args,
+    uId,
+    uInfo
+  ) {
+    checkParams(args)
+
+    const {
+      userId,
+      userInfo
+    } = await checkJobAndGetUserData(
+      reportService,
+      args,
+      uId,
+      uInfo
+    )
+
+    const csvArgs = getCsvArgs(args, 'fundingTrades')
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getFundingTrades',
+      args: csvArgs,
+      propNameForPagination: 'mtsCreate',
+      columnsCsv: {
+        id: '#',
+        symbol: 'PAIR',
+        amount: 'AMOUNT',
+        rate: 'RATE',
+        period: 'PERIOD',
+        maker: 'MAKER',
+        mtsCreate: 'DATE',
+        offerID: 'OFFER ID'
+      },
+      formatSettings: {
+        mtsCreate: 'date',
+        symbol: 'symbol'
+      }
+    }
+
+    return jobData
+  },
   async getTickersHistoryCsvJobData (
     reportService,
     args,

--- a/workers/loc.api/helpers/limit-param.helpers.js
+++ b/workers/loc.api/helpers/limit-param.helpers.js
@@ -7,6 +7,7 @@ const getMethodLimit = (sendLimit, method, methodsLimits = {}) => {
     positionsAudit: { default: 100, max: 250 },
     ledgers: { default: 250, max: 500 },
     trades: { default: 500, max: 1000 },
+    fundingTrades: { default: 500, max: 1000 },
     publicTrades: { default: 500, max: 5000 },
     orders: { default: 250, max: 500 },
     movements: { default: 25, max: 25 },

--- a/workers/loc.api/helpers/prepare-response.js
+++ b/workers/loc.api/helpers/prepare-response.js
@@ -109,6 +109,13 @@ const _getSymbolParam = (
     return symbol.length > 1 ? null : symbol[0]
   }
 
+  if (
+    !symbol &&
+    methodApi === 'fundingTrades'
+  ) {
+    return null
+  }
+
   return symbol
 }
 

--- a/workers/loc.api/queue/helpers.js
+++ b/workers/loc.api/queue/helpers.js
@@ -116,7 +116,10 @@ const _formatters = {
     return val
   },
   symbol: symbol => {
-    if (symbol[0] !== 't') {
+    if (
+      symbol[0] !== 't' &&
+      symbol[0] !== 'f'
+    ) {
       return symbol
     }
 
@@ -422,6 +425,7 @@ const _writeMessageToStream = (reportService, stream, message) => {
 
 const _fileNamesMap = new Map([
   ['getTrades', 'trades'],
+  ['getFundingTrades', 'funding_trades'],
   ['getPublicTrades', 'public_trades'],
   ['getPublicFunding', 'public_funding'],
   ['getLedgers', 'ledgers'],

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -262,6 +262,22 @@ class ReportService extends Api {
     }
   }
 
+  async getFundingTrades (space, args, cb) {
+    try {
+      const res = await prepareApiResponse(
+        args,
+        this.ctx.grc_bfx.caller,
+        'fundingTrades',
+        'mtsCreate',
+        'symbol'
+      )
+
+      cb(null, res)
+    } catch (err) {
+      this._err(err, 'getFundingTrades', cb)
+    }
+  }
+
   async getPublicTrades (space, args, cb) {
     try {
       args.auth = {}

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -14,6 +14,7 @@ const {
 } = require('./helpers')
 const {
   getTradesCsvJobData,
+  getFundingTradesCsvJobData,
   getTickersHistoryCsvJobData,
   getWalletsCsvJobData,
   getPositionsHistoryCsvJobData,
@@ -418,6 +419,20 @@ class ReportService extends Api {
       cb(null, status)
     } catch (err) {
       this._err(err, 'getTradesCsv', cb)
+    }
+  }
+
+  async getFundingTradesCsv (space, args, cb) {
+    try {
+      const status = await getCsvStoreStatus(this, args)
+      const jobData = await getFundingTradesCsvJobData(this, args)
+      const processorQueue = this.ctx.lokue_processor.q
+
+      processorQueue.addJob(jobData)
+
+      cb(null, status)
+    } catch (err) {
+      this._err(err, 'getFundingTradesCsv', cb)
     }
   }
 

--- a/workers/loc.api/service.report.mediator.js
+++ b/workers/loc.api/service.report.mediator.js
@@ -543,6 +543,31 @@ class MediatorReportService extends ReportService {
   /**
    * @override
    */
+  async getFundingTrades (space, args, cb) {
+    try {
+      if (!await this.isSyncModeWithDbData(space, args)) {
+        super.getFundingTrades(space, args, cb)
+
+        return
+      }
+
+      checkParams(args, 'paramsSchemaForApi')
+
+      const res = await this.dao.findInCollBy(
+        '_getFundingTrades',
+        args,
+        true
+      )
+
+      cb(null, res)
+    } catch (err) {
+      cb(err)
+    }
+  }
+
+  /**
+   * @override
+   */
   async getPublicTrades (space, args, cb) {
     try {
       if (!await this.isSyncModeWithDbData(space, args)) {
@@ -841,6 +866,10 @@ class MediatorReportService extends ReportService {
 
   _getTrades (args) {
     return promisify(super.getTrades.bind(this))(null, args)
+  }
+
+  _getFundingTrades (args) {
+    return promisify(super.getFundingTrades.bind(this))(null, args)
   }
 
   _getPublicTrades (args) {

--- a/workers/loc.api/sync/allowed.colls.js
+++ b/workers/loc.api/sync/allowed.colls.js
@@ -6,6 +6,7 @@ module.exports = {
   PRIVATE: '_PRIVATE',
   LEDGERS: 'ledgers',
   TRADES: 'trades',
+  FUNDING_TRADES: 'fundingTrades',
   PUBLIC_TRADES: 'publicTrades',
   ORDERS: 'orders',
   MOVEMENTS: 'movements',

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -74,7 +74,7 @@ const _models = new Map([
       period: 'BIGINT',
       maker: 'INT',
       user_id: `INT NOT NULL,
-        CONSTRAINT trades_fk_#{field}
+        CONSTRAINT fundingTrades_fk_#{field}
         FOREIGN KEY (#{field})
         REFERENCES users(_id)
         ON UPDATE CASCADE

--- a/workers/loc.api/sync/schema.js
+++ b/workers/loc.api/sync/schema.js
@@ -62,6 +62,26 @@ const _models = new Map([
     }
   ],
   [
+    ALLOWED_COLLS.FUNDING_TRADES,
+    {
+      _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',
+      id: 'BIGINT',
+      symbol: 'VARCHAR(255)',
+      mtsCreate: 'BIGINT',
+      offerID: 'BIGINT',
+      amount: 'DECIMAL(22,12)',
+      rate: 'DECIMAL(22,12)',
+      period: 'BIGINT',
+      maker: 'INT',
+      user_id: `INT NOT NULL,
+        CONSTRAINT trades_fk_#{field}
+        FOREIGN KEY (#{field})
+        REFERENCES users(_id)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE`
+    }
+  ],
+  [
     ALLOWED_COLLS.PUBLIC_TRADES,
     {
       _id: 'INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT',
@@ -365,6 +385,21 @@ const _methodCollMap = new Map([
       type: 'insertable:array:objects',
       fieldsOfUniqueIndex: ['id', 'mtsCreate', 'orderID', 'fee'],
       model: { ..._models.get(ALLOWED_COLLS.TRADES) }
+    }
+  ],
+  [
+    '_getFundingTrades',
+    {
+      name: ALLOWED_COLLS.FUNDING_TRADES,
+      maxLimit: 1000,
+      dateFieldName: 'mtsCreate',
+      symbolFieldName: 'symbol',
+      sort: [['mtsCreate', -1]],
+      hasNewData: false,
+      start: 0,
+      type: 'insertable:array:objects',
+      fieldsOfUniqueIndex: ['id', 'mtsCreate', 'offerID'],
+      model: { ..._models.get(ALLOWED_COLLS.FUNDING_TRADES) }
     }
   ],
   [


### PR DESCRIPTION
This PR adds the funding trades report. Base changes:

  - adds `getFundingTrades` method
  - adds `getFundingTradesCsv` method
  - adds funding trades to sync mode
  - adds tests coverage of `getFundingTrades` and `getFundingTradesCsv` methods

**Depends** on this PR [bfx-api-mock-srv#19](https://github.com/bitfinexcom/bfx-api-mock-srv/pull/19)