### PR TITLE
Add ability to override schema to findInCollBy method of SqliteDAO

### DIFF
--- a/workers/loc.api/service.report.mediator.js
+++ b/workers/loc.api/service.report.mediator.js
@@ -371,14 +371,16 @@ class MediatorReportService extends ReportService {
       const symbols = await this.dao.findInCollBy(
         symbolsMethod,
         args,
-        false,
-        true
+        {
+          isPublic: true
+        }
       )
       const currencies = await this.dao.findInCollBy(
         currenciesMethod,
         args,
-        false,
-        true
+        {
+          isPublic: true
+        }
       )
       const pairs = collObjToArr(symbols, field)
       const res = { pairs, currencies }
@@ -449,8 +451,10 @@ class MediatorReportService extends ReportService {
       const res = await this.dao.findInCollBy(
         '_getTickersHistory',
         args,
-        true,
-        true
+        {
+          isPrepareResponse: true,
+          isPublic: true
+        }
       )
 
       cb(null, res)
@@ -475,7 +479,9 @@ class MediatorReportService extends ReportService {
       const res = await this.dao.findInCollBy(
         '_getPositionsHistory',
         args,
-        true
+        {
+          isPrepareResponse: true
+        }
       )
 
       cb(null, res)
@@ -506,7 +512,9 @@ class MediatorReportService extends ReportService {
       const res = await this.dao.findInCollBy(
         '_getLedgers',
         args,
-        true
+        {
+          isPrepareResponse: true
+        }
       )
 
       cb(null, res)
@@ -531,7 +539,9 @@ class MediatorReportService extends ReportService {
       const res = await this.dao.findInCollBy(
         '_getTrades',
         args,
-        true
+        {
+          isPrepareResponse: true
+        }
       )
 
       cb(null, res)
@@ -556,7 +566,9 @@ class MediatorReportService extends ReportService {
       const res = await this.dao.findInCollBy(
         '_getFundingTrades',
         args,
-        true
+        {
+          isPrepareResponse: true
+        }
       )
 
       cb(null, res)
@@ -608,8 +620,10 @@ class MediatorReportService extends ReportService {
       const res = await this.dao.findInCollBy(
         '_getPublicTrades',
         args,
-        true,
-        true
+        {
+          isPrepareResponse: true,
+          isPublic: true
+        }
       )
 
       cb(null, res)
@@ -634,7 +648,9 @@ class MediatorReportService extends ReportService {
       const res = await this.dao.findInCollBy(
         '_getOrders',
         args,
-        true
+        {
+          isPrepareResponse: true
+        }
       )
 
       cb(null, res)
@@ -659,7 +675,9 @@ class MediatorReportService extends ReportService {
       const res = await this.dao.findInCollBy(
         '_getMovements',
         args,
-        true
+        {
+          isPrepareResponse: true
+        }
       )
 
       cb(null, res)
@@ -684,7 +702,9 @@ class MediatorReportService extends ReportService {
       const res = await this.dao.findInCollBy(
         '_getFundingOfferHistory',
         args,
-        true
+        {
+          isPrepareResponse: true
+        }
       )
 
       cb(null, res)
@@ -709,7 +729,9 @@ class MediatorReportService extends ReportService {
       const res = await this.dao.findInCollBy(
         '_getFundingLoanHistory',
         args,
-        true
+        {
+          isPrepareResponse: true
+        }
       )
 
       cb(null, res)
@@ -734,7 +756,9 @@ class MediatorReportService extends ReportService {
       const res = await this.dao.findInCollBy(
         '_getFundingCreditHistory',
         args,
-        true
+        {
+          isPrepareResponse: true
+        }
       )
 
       cb(null, res)

--- a/workers/loc.api/sync/dao/dao.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.sqlite.js
@@ -292,7 +292,7 @@ class SqliteDAO extends DAO {
       isPublic = false,
       additionalModel,
       schema = {}
-    }) {
+    } = {}) {
     const user = isPublic ? null : await this.checkAuthInDb(args)
     const methodColl = {
       ...this._getMethodCollMap().get(method),

--- a/workers/loc.api/sync/dao/dao.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.sqlite.js
@@ -284,9 +284,20 @@ class SqliteDAO extends DAO {
   /**
    * @override
    */
-  async findInCollBy (method, args, isPrepareResponse, isPublic) {
+  async findInCollBy (
+    method,
+    args,
+    {
+      isPrepareResponse = false,
+      isPublic = false,
+      additionalModel,
+      schema = {}
+    }) {
     const user = isPublic ? null : await this.checkAuthInDb(args)
-    const methodColl = this._getMethodCollMap().get(method)
+    const methodColl = {
+      ...this._getMethodCollMap().get(method),
+      ...schema
+    }
     const params = { ...args.params }
     const {
       maxLimit,
@@ -299,6 +310,7 @@ class SqliteDAO extends DAO {
     params.limit = maxLimit
       ? getLimitNotMoreThan(params.limit, maxLimit)
       : null
+    const _model = { ...model, ...additionalModel }
 
     const exclude = ['_id']
     const filter = getInsertableArrayObjectsFilter(
@@ -323,7 +335,7 @@ class SqliteDAO extends DAO {
     const group = getGroupQuery(methodColl)
     const subQuery = getSubQuery(methodColl)
     const projection = getProjectionQuery(
-      model,
+      _model,
       exclude,
       true
     )


### PR DESCRIPTION
This PR adds an ability to override schema to the `findInCollBy` method of the `SqliteDAO`.
This change is necessary for [bfx-reports-framework#15](https://github.com/bitfinexcom/bfx-reports-framework/pull/15)