### PR TITLE
Fix isRateLimitError helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Reporting tool",
   "main": "worker.js",
   "license": "Apache-2.0",

--- a/workers/loc.api/helpers/api-errors-testers.js
+++ b/workers/loc.api/helpers/api-errors-testers.js
@@ -13,7 +13,7 @@ const isEaiAgainError = (err) => {
 }
 
 const isRateLimitError = (err) => {
-  return /ERR(_RATE)?_LIMIT/.test(err.toString())
+  return /(ERR(_RATE)?_LIMIT)|(ratelimit)/.test(err.toString())
 }
 
 const isNonceSmallError = (err) => {

--- a/workers/loc.api/queue/helpers.js
+++ b/workers/loc.api/queue/helpers.js
@@ -22,7 +22,7 @@ const translations = yaml.safeLoad(fs.readFileSync(pathToTrans, 'utf8'))
 const isElectronjsEnv = argv.isElectronjsEnv
 
 const isRateLimitError = (err) => {
-  return /ERR(_RATE)?_LIMIT/.test(err.toString())
+  return /(ERR(_RATE)?_LIMIT)|(ratelimit)/.test(err.toString())
 }
 
 const isNonceSmallError = (err) => {


### PR DESCRIPTION
This PR fixed the `isRateLimitError` helper. The production `api_v2` server is responded different error message `RateLimit` for the candles endpoint:
```
    statusCode: 429
    name: StatusCodeError
    message: 429 - ["error",11010,"ratelimit: error"]
    options: {"url":"https://api.bitfinex.com/v2/candles/trade:1D:tETHUSD/hist?limit=500&start=1502323200000&end=1514332800000","method":"GET","timeout":15000,"json":true,"simple":true,"resolveWithFullResponse":false,"transform2xxOnly":false}
```