### PR TITLE
Add isExcludePrivate to findInCollBy method of SqliteDAO

### DIFF
--- a/workers/loc.api/sync/dao/dao.sqlite.js
+++ b/workers/loc.api/sync/dao/dao.sqlite.js
@@ -291,7 +291,8 @@ class SqliteDAO extends DAO {
       isPrepareResponse = false,
       isPublic = false,
       additionalModel,
-      schema = {}
+      schema = {},
+      isExcludePrivate = true
     } = {}) {
     const user = isPublic ? null : await this.checkAuthInDb(args)
     const methodColl = {
@@ -337,7 +338,7 @@ class SqliteDAO extends DAO {
     const projection = getProjectionQuery(
       _model,
       exclude,
-      true
+      isExcludePrivate
     )
 
     const sql = `SELECT ${projection} FROM ${subQuery}


### PR DESCRIPTION
This PR adds an `isExcludePrivate` option to the `findInCollBy` method of the `SqliteDAO`, in order to be able to exclude or include private fields to a DB selection