### PR TITLE
Add order trades

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -924,7 +924,7 @@ describe('API', () => {
     ])
   })
 
-  it('it should be successfully performed by the getPublicTrades method, where the symbol is an array with length more then one', async function () {
+  it('it should not be successfully performed by the getPublicTrades method, where the symbol is an array with length more then one', async function () {
     this.timeout(5000)
 
     const res = await agent
@@ -948,6 +948,124 @@ describe('API', () => {
     assert.propertyVal(res.body.error, 'code', 500)
     assert.propertyVal(res.body.error, 'message', 'Internal Server Error')
     assert.propertyVal(res.body, 'id', 5)
+  })
+
+  it('it should be successfully performed by the getOrderTrades method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getOrderTrades',
+        params: {
+          id: 12345,
+          symbol: 'tBTCUSD',
+          start: 0,
+          end,
+          limit: 2
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isArray(res.body.result.res)
+    assert.isNumber(res.body.result.nextPage)
+
+    const resItem = res.body.result.res[0]
+
+    assert.isObject(resItem)
+    assert.containsAllKeys(resItem, [
+      'id',
+      'symbol',
+      'mtsCreate',
+      'orderID',
+      'execAmount',
+      'execPrice',
+      'orderType',
+      'orderPrice',
+      'maker',
+      'fee',
+      'feeCurrency'
+    ])
+  })
+
+  it('it should not be successfully performed by the getOrderTrades method, where the symbol is an array', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getOrderTrades',
+        params: {
+          id: 12345,
+          symbol: ['tBTCUSD', 'tETHUSD'],
+          start: 0,
+          end,
+          limit: 2
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(500)
+
+    assert.isObject(res.body)
+    assert.isObject(res.body.error)
+    assert.propertyVal(res.body.error, 'code', 500)
+    assert.propertyVal(res.body.error, 'message', 'Internal Server Error')
+    assert.propertyVal(res.body, 'id', 5)
+  })
+
+  it('it should be successfully performed by the getOrderTrades method, where the symbol is an array with length equal to one', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getOrderTrades',
+        params: {
+          id: 12345,
+          symbol: ['tBTCUSD'],
+          start: 0,
+          end,
+          limit: 2
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isArray(res.body.result.res)
+    assert.isNumber(res.body.result.nextPage)
+
+    const resItem = res.body.result.res[0]
+
+    assert.isObject(resItem)
+    assert.containsAllKeys(resItem, [
+      'id',
+      'symbol',
+      'mtsCreate',
+      'orderID',
+      'execAmount',
+      'execPrice',
+      'orderType',
+      'orderPrice',
+      'maker',
+      'fee',
+      'feeCurrency'
+    ])
   })
 
   it('it should be successfully performed by the getOrders method', async function () {

--- a/test/2-sync-mode-sqlite.spec.js
+++ b/test/2-sync-mode-sqlite.spec.js
@@ -1403,6 +1403,134 @@ describe('Sync mode with SQLite', () => {
     assert.propertyVal(res.body, 'id', 5)
   })
 
+  it('it should be successfully performed by the getOrderTrades method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getOrderTrades',
+        params: {
+          id: 12345,
+          symbol: 'tBTCUSD',
+          start: 0,
+          end,
+          limit: 2
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isArray(res.body.result.res)
+
+    /**
+     * it should be a boolean because in the DB is contained
+     * one a row with id=12345
+     */
+    assert.isBoolean(res.body.result.nextPage)
+
+    const resItem = res.body.result.res[0]
+
+    assert.isObject(resItem)
+    assert.containsAllKeys(resItem, [
+      'id',
+      'symbol',
+      'mtsCreate',
+      'orderID',
+      'execAmount',
+      'execPrice',
+      'orderType',
+      'orderPrice',
+      'maker',
+      'fee',
+      'feeCurrency'
+    ])
+  })
+
+  it('it should not be successfully performed by the getOrderTrades method, where the symbol is an array', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getOrderTrades',
+        params: {
+          id: 12345,
+          symbol: ['tBTCUSD', 'tETHUSD'],
+          start: 0,
+          end,
+          limit: 2
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(500)
+
+    assert.isObject(res.body)
+    assert.isObject(res.body.error)
+    assert.propertyVal(res.body.error, 'code', 500)
+    assert.propertyVal(res.body.error, 'message', 'Internal Server Error')
+    assert.propertyVal(res.body, 'id', 5)
+  })
+
+  it('it should be successfully performed by the getOrderTrades method, where the symbol is an array with length equal to one', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getOrderTrades',
+        params: {
+          id: 12345,
+          symbol: ['tBTCUSD'],
+          start: 0,
+          end,
+          limit: 2
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isArray(res.body.result.res)
+
+    /**
+     * it should be a boolean because in the DB is contained
+     * one a row with id=12345
+     */
+    assert.isBoolean(res.body.result.nextPage)
+
+    const resItem = res.body.result.res[0]
+
+    assert.isObject(resItem)
+    assert.containsAllKeys(resItem, [
+      'id',
+      'symbol',
+      'mtsCreate',
+      'orderID',
+      'execAmount',
+      'execPrice',
+      'orderType',
+      'orderPrice',
+      'maker',
+      'fee',
+      'feeCurrency'
+    ])
+  })
+
   it('it should be successfully performed by the getOrders method', async function () {
     this.timeout(5000)
 
@@ -2075,6 +2203,35 @@ describe('Sync mode with SQLite', () => {
     assert.propertyVal(res.body.error, 'code', 500)
     assert.propertyVal(res.body.error, 'message', 'Internal Server Error')
     assert.propertyVal(res.body, 'id', 5)
+  })
+
+  it('it should be successfully performed by the getOrderTradesCsv method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getOrderTradesCsv',
+        params: {
+          id: 12345,
+          symbol: 'tBTCUSD',
+          end,
+          start,
+          limit: 1000,
+          timezone: 'America/Los_Angeles',
+          email
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
   it('it should be successfully performed by the getOrdersCsv method', async function () {

--- a/test/3-queue-base.spec.js
+++ b/test/3-queue-base.spec.js
@@ -527,6 +527,35 @@ describe('Queue', () => {
     assert.propertyVal(res.body, 'id', 5)
   })
 
+  it('it should be successfully performed by the getOrderTradesCsv method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getOrderTradesCsv',
+        params: {
+          id: 12345,
+          symbol: 'tBTCUSD',
+          end,
+          start,
+          limit: 1000,
+          timezone: 'America/Los_Angeles',
+          email
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+  })
+
   it('it should be successfully performed by the getOrdersCsv method', async function () {
     this.timeout(60000)
 

--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -88,6 +88,13 @@ const setDataTo = (
       dataItem[1] = _date
       break
 
+    case 'order_trades':
+      dataItem[0] = id
+      dataItem[2] = _date
+      dataItem[3] = id
+      dataItem[9] = fee
+      break
+
     case 'orders':
       dataItem[0] = id
       dataItem[4] = _date
@@ -139,6 +146,7 @@ const getMockDataOpts = () => ({
   trades: { limit: 1000 },
   f_trade_hist: { limit: 1000 },
   public_trades: { limit: 5000 },
+  order_trades: { limit: 1000 },
   orders: { limit: 500 },
   active_orders: { limit: 100 },
   movements: { limit: 25 },

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -192,6 +192,22 @@ module.exports = new Map([
     ]]
   ],
   [
+    'order_trades',
+    [[
+      12345,
+      'tBTCUSD',
+      _ms,
+      12345,
+      0.01,
+      12345,
+      null,
+      null,
+      false,
+      -0.00001,
+      'BTC'
+    ]]
+  ],
+  [
     'orders',
     [[
       12345,

--- a/workers/loc.api/helpers/get-csv-job-data.js
+++ b/workers/loc.api/helpers/get-csv-job-data.js
@@ -437,6 +437,50 @@ const getCsvJobData = {
 
     return jobData
   },
+  async getOrderTradesCsvJobData (
+    reportService,
+    args,
+    uId,
+    uInfo
+  ) {
+    checkParams(args, 'paramsSchemaForOrderTradesCsv')
+
+    const {
+      userId,
+      userInfo
+    } = await checkJobAndGetUserData(
+      reportService,
+      args,
+      uId,
+      uInfo
+    )
+
+    const csvArgs = getCsvArgs(args, 'orderTrades')
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getOrderTrades',
+      args: csvArgs,
+      propNameForPagination: 'mtsCreate',
+      columnsCsv: {
+        id: '#',
+        symbol: 'PAIR',
+        execAmount: 'AMOUNT',
+        execPrice: 'PRICE',
+        fee: 'FEE',
+        feeCurrency: 'FEE CURRENCY',
+        mtsCreate: 'DATE',
+        orderID: 'ORDER ID'
+      },
+      formatSettings: {
+        mtsCreate: 'date',
+        symbol: 'symbol'
+      }
+    }
+
+    return jobData
+  },
   async getOrdersCsvJobData (
     reportService,
     args,

--- a/workers/loc.api/helpers/limit-param.helpers.js
+++ b/workers/loc.api/helpers/limit-param.helpers.js
@@ -7,6 +7,7 @@ const getMethodLimit = (sendLimit, method, methodsLimits = {}) => {
     positionsAudit: { default: 100, max: 250 },
     ledgers: { default: 250, max: 500 },
     trades: { default: 500, max: 1000 },
+    orderTrades: { default: 500, max: 1000 },
     fundingTrades: { default: 500, max: 1000 },
     publicTrades: { default: 500, max: 5000 },
     orders: { default: 250, max: 500 },

--- a/workers/loc.api/helpers/prepare-response.js
+++ b/workers/loc.api/helpers/prepare-response.js
@@ -20,6 +20,13 @@ const _paramsOrderMap = {
     'end',
     'limit'
   ],
+  orderTrades: [
+    'symbol',
+    'start',
+    'end',
+    'limit',
+    'id'
+  ],
   default: [
     'symbol',
     'start',
@@ -31,6 +38,7 @@ const _paramsOrderMap = {
 const _paramsSchemasMap = {
   publicTrades: 'paramsSchemaForPublicTrades',
   positionsAudit: 'paramsSchemaForPositionsAudit',
+  orderTrades: 'paramsSchemaForOrderTradesApi',
   default: 'paramsSchemaForApi'
 }
 

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -207,6 +207,7 @@ const paramsSchemaForOrderTradesApi = {
         type: 'array'
       },
       then: {
+        minItems: 1,
         maxItems: 1,
         items: {
           type: 'string'

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -216,6 +216,16 @@ const paramsSchemaForOrderTradesApi = {
   }
 }
 
+const paramsSchemaForOrderTradesCsv = {
+  ...paramsSchemaForOrderTradesApi,
+  properties: {
+    ...paramsSchemaForOrderTradesApi.properties,
+    timezone,
+    dateFormat,
+    language
+  }
+}
+
 module.exports = {
   paramsSchemaForApi,
   paramsSchemaForCsv,
@@ -228,5 +238,6 @@ module.exports = {
   paramsSchemaForWalletsCsv,
   paramsSchemaForMultipleCsv,
   paramsSchemaForActivePositionsCsv,
-  paramsSchemaForOrderTradesApi
+  paramsSchemaForOrderTradesApi,
+  paramsSchemaForOrderTradesCsv
 }

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -185,6 +185,37 @@ const paramsSchemaForMultipleCsv = {
   }
 }
 
+const paramsSchemaForOrderTradesApi = {
+  type: 'object',
+  required: ['id', 'symbol'],
+  properties: {
+    id: {
+      type: 'integer'
+    },
+    limit: {
+      type: 'integer'
+    },
+    start: {
+      type: 'integer'
+    },
+    end: {
+      type: 'integer'
+    },
+    symbol: {
+      type: ['string', 'array'],
+      if: {
+        type: 'array'
+      },
+      then: {
+        maxItems: 1,
+        items: {
+          type: 'string'
+        }
+      }
+    }
+  }
+}
+
 module.exports = {
   paramsSchemaForApi,
   paramsSchemaForCsv,
@@ -196,5 +227,6 @@ module.exports = {
   paramsSchemaForWallets,
   paramsSchemaForWalletsCsv,
   paramsSchemaForMultipleCsv,
-  paramsSchemaForActivePositionsCsv
+  paramsSchemaForActivePositionsCsv,
+  paramsSchemaForOrderTradesApi
 }

--- a/workers/loc.api/queue/helpers.js
+++ b/workers/loc.api/queue/helpers.js
@@ -428,6 +428,7 @@ const _writeMessageToStream = (reportService, stream, message) => {
 
 const _fileNamesMap = new Map([
   ['getTrades', 'trades'],
+  ['getOrderTrades', 'order_trades'],
   ['getFundingTrades', 'funding_trades'],
   ['getPublicTrades', 'public_trades'],
   ['getPublicFunding', 'public_funding'],

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -28,6 +28,7 @@ const {
   getFundingOfferHistoryCsvJobData,
   getFundingLoanHistoryCsvJobData,
   getFundingCreditHistoryCsvJobData,
+  getOrderTradesCsvJobData,
   getMultipleCsvJobData
 } = require('./helpers/get-csv-job-data')
 const { ArgsParamsError } = require('./errors')
@@ -558,6 +559,20 @@ class ReportService extends Api {
       cb(null, status)
     } catch (err) {
       this._err(err, 'getLedgersCsv', cb)
+    }
+  }
+
+  async getOrderTradesCsv (space, args, cb) {
+    try {
+      const status = await getCsvStoreStatus(this, args)
+      const jobData = await getOrderTradesCsvJobData(this, args)
+      const processorQueue = this.ctx.lokue_processor.q
+
+      processorQueue.addJob(jobData)
+
+      cb(null, status)
+    } catch (err) {
+      this._err(err, 'getOrderTradesCsv', cb)
     }
   }
 

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -308,6 +308,22 @@ class ReportService extends Api {
     }
   }
 
+  async getOrderTrades (space, args, cb) {
+    try {
+      const res = await prepareApiResponse(
+        args,
+        this.ctx.grc_bfx.caller,
+        'orderTrades',
+        'mtsCreate',
+        'symbol'
+      )
+
+      cb(null, res)
+    } catch (err) {
+      this._err(err, 'getOrderTrades', cb)
+    }
+  }
+
   async getOrders (space, args, cb) {
     try {
       const res = await prepareApiResponse(

--- a/workers/loc.api/service.report.mediator.js
+++ b/workers/loc.api/service.report.mediator.js
@@ -644,6 +644,38 @@ class MediatorReportService extends ReportService {
   /**
    * @override
    */
+  async getOrderTrades (space, args, cb) {
+    try {
+      if (!await this.isSyncModeWithDbData(space, args)) {
+        super.getOrderTrades(space, args, cb)
+
+        return
+      }
+
+      checkParams(args, 'paramsSchemaForOrderTradesApi')
+
+      const { id: orderID } = { ...args.params }
+
+      const res = await this.dao.findInCollBy(
+        '_getTrades',
+        args,
+        {
+          isPrepareResponse: true,
+          schema: {
+            additionalFilteringProps: { orderID }
+          }
+        }
+      )
+
+      cb(null, res)
+    } catch (err) {
+      cb(err)
+    }
+  }
+
+  /**
+   * @override
+   */
   async getOrders (space, args, cb) {
     try {
       if (!await this.isSyncModeWithDbData(space, args)) {

--- a/workers/loc.api/sync/dao/helpers/get-insertable-array-objects-filter.js
+++ b/workers/loc.api/sync/dao/helpers/get-insertable-array-objects-filter.js
@@ -22,7 +22,8 @@ module.exports = (
     type,
     dateFieldName,
     model,
-    symbolFieldName
+    symbolFieldName,
+    additionalFilteringProps
   } = {},
   params = {}
 ) => {
@@ -38,7 +39,8 @@ module.exports = (
   const filter = {
     _dateFieldName: dateFieldName,
     start,
-    end
+    end,
+    ...additionalFilteringProps
   }
 
   if (


### PR DESCRIPTION
This PR adds order trades which can get by order id. Basic changes:
  - adds `getOrderTrades` method
  - adds `getOrderTradesCsv` method
  - adds `getOrderTrades` method to the sync mode
  - adds corresponding test coverage