### PR TITLE
Add meta and collateral fields to positions audit

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -389,7 +389,10 @@ describe('API', () => {
       'placeholder',
       'id',
       'mtsCreate',
-      'mtsUpdate'
+      'mtsUpdate',
+      'collateral',
+      'collateralMin',
+      'meta'
     ])
   })
 

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -142,7 +142,13 @@ module.exports = new Map([
       null,
       12345,
       _ms,
-      _ms
+      _ms,
+      null,
+      1,
+      null,
+      12345,
+      12345,
+      JSON.stringify({ someMetaData: 'someMetaData' })
     ]]
   ],
   [

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -341,7 +341,10 @@ class CsvJobData {
         status: 'STATUS',
         mtsUpdate: 'UPDATED',
         mtsCreate: 'CREATED',
-        leverage: 'LEVERAGE'
+        leverage: 'LEVERAGE',
+        collateral: 'COLLATERAL',
+        collateralMin: 'MIN COLLATERAL',
+        meta: 'META INFORMATION'
       },
       formatSettings: {
         mtsUpdate: 'date',


### PR DESCRIPTION
This PR adds `meta`, `collateral`, `collateralMin` fields to the positions audit report