### PR TITLE
Add status messages report

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -923,6 +923,42 @@ describe('API', () => {
     ])
   })
 
+  it('it should be successfully performed by the getStatusMessages method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        method: 'getStatusMessages',
+        params: {
+          symbol: 'tBTCF0:USTF0'
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isArray(res.body.result.res)
+    assert.isBoolean(res.body.result.nextPage)
+
+    const resItem = res.body.result.res[0]
+
+    assert.isObject(resItem)
+    assert.containsAllKeys(resItem, [
+      'key',
+      'timestamp',
+      'price',
+      'priceSpot',
+      'fundBal',
+      'fundingAccrued',
+      'fundingStep'
+    ])
+  })
+
   it('it should be successfully performed by the getPublicTrades method, where the symbol is an array with length equal to one', async function () {
     this.timeout(5000)
 

--- a/test/4-queue-base.spec.js
+++ b/test/4-queue-base.spec.js
@@ -440,6 +440,31 @@ describe('Queue', () => {
     await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
+  it('it should be successfully performed by the getStatusMessagesCsv method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getStatusMessagesCsv',
+        params: {
+          symbol: ['tBTCF0:USTF0'],
+          timezone: 'America/Los_Angeles',
+          email
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+  })
+
   it('it should be successfully performed by the getPublicTradesCsv method', async function () {
     this.timeout(60000)
 

--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -39,6 +39,11 @@ const setDataTo = (
   const _date = Math.round(date)
 
   switch (key) {
+    case 'status_messages':
+      dataItem[1] = _date
+      dataItem[8] = _date
+      break
+
     case 'tickers_hist':
       dataItem[15] = _date
       break
@@ -146,6 +151,7 @@ const getMockDataOpts = () => ({
   trades: { limit: 1000 },
   f_trade_hist: { limit: 1000 },
   public_trades: { limit: 5000 },
+  status_messages: { limit: 10, isNotMoreThanLimit: true },
   order_trades: { limit: 1000 },
   orders: { limit: 500 },
   active_orders: { limit: 100 },

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -191,6 +191,24 @@ module.exports = new Map([
     ]]
   ],
   [
+    'status_messages',
+    [[
+      'tBTCF0:USTF0',
+      _ms,
+      null,
+      8402.8,
+      8412.8,
+      null,
+      101091.28492701,
+      null,
+      _ms,
+      -0.00019831,
+      5534,
+      null,
+      0.0006622
+    ]]
+  ],
+  [
     'f_trade_hist',
     [[
       12345,

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -412,6 +412,47 @@ class CsvJobData {
     return jobData
   }
 
+  async getStatusMessagesCsvJobData (
+    args,
+    uId,
+    uInfo
+  ) {
+    checkParams(args, 'paramsSchemaForStatusMessagesCsv')
+
+    const {
+      userId,
+      userInfo
+    } = await checkJobAndGetUserData(
+      this.rService,
+      args,
+      uId,
+      uInfo
+    )
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getStatusMessages',
+      args,
+      propNameForPagination: 'timestamp',
+      columnsCsv: {
+        key: 'PAIR',
+        price: 'DERIV PRICE',
+        priceSpot: 'SPOT PRICE',
+        fundBal: 'INSURANCE RUND BALANCE',
+        fundingAccrued: 'NEXT FUNDING ACCRUED',
+        fundingStep: 'NEXT FUNDING STEP',
+        timestamp: 'UPDATED'
+      },
+      formatSettings: {
+        timestamp: 'date',
+        key: 'symbol'
+      }
+    }
+
+    return jobData
+  }
+
   async getLedgersCsvJobData (
     args,
     uId,

--- a/workers/loc.api/helpers/prepare-response.js
+++ b/workers/loc.api/helpers/prepare-response.js
@@ -2,6 +2,7 @@
 
 const {
   cloneDeep,
+  isEmpty,
   omit
 } = require('lodash')
 
@@ -13,6 +14,10 @@ const { getDateNotMoreNow } = require('./date-param.helpers')
 const { MinLimitParamError } = require('../errors')
 
 const _paramsOrderMap = {
+  statusMessages: [
+    'type',
+    'symbol'
+  ],
   positionsHistory: [
     'start',
     'end',
@@ -40,6 +45,7 @@ const _paramsOrderMap = {
 }
 
 const _paramsSchemasMap = {
+  statusMessages: 'paramsSchemaForStatusMessagesApi',
   publicTrades: 'paramsSchemaForPublicTrades',
   positionsAudit: 'paramsSchemaForPositionsAudit',
   orderTrades: 'paramsSchemaForOrderTradesApi',
@@ -83,7 +89,8 @@ const _getSymbols = (
     typeof symbPropName !== 'string' ||
     !args.params ||
     typeof args.params !== 'object' ||
-    !args.params.symbol
+    !args.params.symbol ||
+    methodApi === 'statusMessages'
   ) {
     return null
   }
@@ -113,6 +120,17 @@ const _getSymbolParam = (
   symbPropName
 ) => {
   if (
+    methodApi === 'statusMessages'
+  ) {
+    const _symbol = isEmpty(symbol)
+      ? 'ALL'
+      : symbol
+
+    return Array.isArray(_symbol)
+      ? _symbol
+      : [_symbol]
+  }
+  if (
     typeof symbPropName === 'string' &&
     methodApi !== 'positionsHistory' &&
     methodApi !== 'positionsAudit' &&
@@ -120,7 +138,6 @@ const _getSymbolParam = (
   ) {
     return symbol.length > 1 ? null : symbol[0]
   }
-
   if (
     !symbol &&
     methodApi === 'fundingTrades'

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -98,6 +98,16 @@ const paramsSchemaForStatusMessagesApi = {
   }
 }
 
+const paramsSchemaForStatusMessagesCsv = {
+  type: 'object',
+  properties: {
+    ...paramsSchemaForStatusMessagesApi.properties,
+    timezone,
+    dateFormat,
+    language
+  }
+}
+
 const paramsSchemaForCsv = {
   ...paramsSchemaForApi,
   properties: {
@@ -263,5 +273,6 @@ module.exports = {
   paramsSchemaForActivePositionsCsv,
   paramsSchemaForOrderTradesApi,
   paramsSchemaForOrderTradesCsv,
-  paramsSchemaForStatusMessagesApi
+  paramsSchemaForStatusMessagesApi,
+  paramsSchemaForStatusMessagesCsv
 }

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -77,6 +77,27 @@ const language = {
   enum: ['en', 'ru', 'zh-CN', 'zh-TW']
 }
 
+const paramsSchemaForStatusMessagesApi = {
+  type: 'object',
+  properties: {
+    type: {
+      type: 'string'
+    },
+    symbol: {
+      type: ['string', 'array'],
+      if: {
+        type: 'array'
+      },
+      then: {
+        minItems: 1,
+        items: {
+          type: 'string'
+        }
+      }
+    }
+  }
+}
+
 const paramsSchemaForCsv = {
   ...paramsSchemaForApi,
   properties: {
@@ -241,5 +262,6 @@ module.exports = {
   paramsSchemaForMultipleCsv,
   paramsSchemaForActivePositionsCsv,
   paramsSchemaForOrderTradesApi,
-  paramsSchemaForOrderTradesCsv
+  paramsSchemaForOrderTradesCsv,
+  paramsSchemaForStatusMessagesApi
 }

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -450,6 +450,15 @@ class ReportService extends Api {
     }, 'getPublicTradesCsv', cb)
   }
 
+  getStatusMessagesCsv (space, args, cb) {
+    return this._responder(() => {
+      return this._generateCsv(
+        'getStatusMessagesCsvJobData',
+        args
+      )
+    }, 'getStatusMessagesCsv', cb)
+  }
+
   getLedgersCsv (space, args, cb) {
     return this._responder(() => {
       return this._generateCsv(

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -254,6 +254,33 @@ class ReportService extends Api {
     }, 'getPublicTrades', cb)
   }
 
+  getStatusMessages (space, args, cb) {
+    return this._responder(() => {
+      const { params } = { ...args }
+      const {
+        type = 'deriv',
+        symbol = ['ALL']
+      } = { ...params }
+      const _args = {
+        ...args,
+        auth: {},
+        params: {
+          ...params,
+          type,
+          symbol,
+          notCheckNextPage: true
+        }
+      }
+
+      return this._prepareApiResponse(
+        _args,
+        'statusMessages',
+        'timestamp',
+        ['key']
+      )
+    }, 'getStatusMessages', cb)
+  }
+
   getOrderTrades (space, args, cb) {
     return this._responder(() => {
       return this._prepareApiResponse(


### PR DESCRIPTION
This PR adds status messages report. Basic changes:
  - adds `getStatusMessages` method to the main service
  - adds `getStatusMessagesCsv` method to the main service
  - adds corresponding test coverage

Example of a request:
```js
{
    "auth": {
        "apiKey": "---",
        "apiSecret": "---"
    },
    "method": "getStatusMessagesCsv",
    "params": {
    	"type": "deriv", // by default
    	"symbol": ["tBTCF0:USTF0", "tETHF0:USTF0"],  // ['ALL'] by default
    }
}
```