### PR TITLE
Fix movements filtering

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -325,7 +325,6 @@ describe('API', () => {
       'plPerc',
       'liquidationPrice',
       'leverage',
-      'placeholder',
       'id',
       'mtsCreate',
       'mtsUpdate'
@@ -364,7 +363,6 @@ describe('API', () => {
       'plPerc',
       'liquidationPrice',
       'leverage',
-      'placeholder',
       'id',
       'mtsCreate',
       'mtsUpdate',
@@ -415,7 +413,6 @@ describe('API', () => {
       'plPerc',
       'liquidationPrice',
       'leverage',
-      'placeholder',
       'id',
       'mtsCreate',
       'mtsUpdate',
@@ -455,7 +452,6 @@ describe('API', () => {
       'balance',
       'unsettledInterest',
       'balanceAvailable',
-      'placeHolder',
       'mtsUpdate'
     ])
   })

--- a/test/2-api-filter.spec.js
+++ b/test/2-api-filter.spec.js
@@ -139,7 +139,6 @@ describe('API filter', () => {
               'plPerc',
               'liquidationPrice',
               'leverage',
-              'placeholder',
               'id',
               'mtsCreate',
               'mtsUpdate'
@@ -178,7 +177,6 @@ describe('API filter', () => {
               'plPerc',
               'liquidationPrice',
               'leverage',
-              'placeholder',
               'id',
               'mtsCreate',
               'mtsUpdate',

--- a/workers/loc.api/queue/write-data-to-stream/helpers.js
+++ b/workers/loc.api/queue/write-data-to-stream/helpers.js
@@ -221,25 +221,24 @@ const getDataFromApi = async (getData, args) => {
   return res
 }
 
-const filterMovementsByAmount = (res, args) => {
+const filterMovementsByAmount = (res, { params }) => {
+  const {
+    isDeposits,
+    isWithdrawals
+  } = { ...params }
+
   if (
-    args.params.isDeposits ||
-    args.params.isWithdrawals
+    !Array.isArray(res) ||
+    (!isDeposits && !isWithdrawals)
   ) {
-    const _res = res.filter((item) => {
-      return args.params.isDeposits
-        ? item.amount > 0
-        : item.amount < 0
-    })
-
-    if (_res.length === 0) {
-      return false
-    }
-
-    return _res
+    return res
   }
 
-  return res
+  return res.filter((item) => {
+    return isDeposits
+      ? item.amount > 0
+      : item.amount < 0
+  })
 }
 
 const progress = (

--- a/workers/loc.api/queue/write-data-to-stream/index.js
+++ b/workers/loc.api/queue/write-data-to-stream/index.js
@@ -55,13 +55,16 @@ module.exports = (
     const isGetActivePositionsMethod = (
       method === 'getActivePositions'
     )
-    let { res, nextPage } = (
+    const { res: apiRes, nextPage } = (
       isGetWalletsMethod ||
       isGetActivePositionsMethod ||
       Object.keys({ ..._res }).every(key => key !== 'nextPage')
     )
       ? { res: _res, nextPage: null }
       : _res
+    let res = method === 'getMovements'
+      ? filterMovementsByAmount(apiRes, _args)
+      : apiRes
 
     currIterationArgs.params.end = nextPage
 
@@ -88,15 +91,6 @@ module.exports = (
       if (count > 0) processorQueue.emit('progress', 100)
 
       break
-    }
-    if (method === 'getMovements') {
-      res = filterMovementsByAmount(res, _args)
-
-      if (!res) {
-        if (count > 0) processorQueue.emit('progress', 100)
-
-        break
-      }
     }
 
     const lastItem = res[res.length - 1]


### PR DESCRIPTION
This PR fixes movements filtering:
  - fixes the following issue, when the `nextPage` field (in response) is an integer but the data array is empty export csv is not gone to the next page
  - fixes test cases for the `getPositionsAudit` and `getWallets` methods related to the changes of [bfx-api-node-models](https://github.com/bitfinexcom/bfx-api-node-models/commit/b2af1131f8a225d994e7473c3782385c05e4e6d6#diff-3f88a395e968f1aeeac7d06262610561L16)