### PR TITLE
Fix second call request condition to api_v2

### DIFF
--- a/workers/loc.api/helpers/prepare-response.js
+++ b/workers/loc.api/helpers/prepare-response.js
@@ -225,6 +225,7 @@ const _isNotContainedSameMts = (
   )
 
   return (
+    apiRes.length === 0 ||
     methodLimit > limit ||
     apiRes.some((item) => {
       const _item = { ...item }


### PR DESCRIPTION
This PR fixes second call request condition to the `api_v2`, do not make a second call with max limit to the `api_v2` if the first call is empty