### PR TITLE
Add ability to specify paths to writing files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Reporting tool",
   "main": "worker.js",
   "license": "Apache-2.0",

--- a/workers/api.service.report.wrk.js
+++ b/workers/api.service.report.wrk.js
@@ -2,13 +2,27 @@
 
 const { WrkApi } = require('bfx-wrk-api')
 const async = require('async')
+const path = require('path')
 const argv = require('yargs')
   .option('dbId', {
     type: 'number',
     default: 1
   })
   .option('csvFolder', {
-    type: 'string'
+    type: 'string',
+    default: 'csv'
+  })
+  .option('tempFolder', {
+    type: 'string',
+    default: 'workers/loc.api/queue/temp'
+  })
+  .option('logsFolder', {
+    type: 'string',
+    default: 'logs'
+  })
+  .option('dbFolder', {
+    type: 'string',
+    default: 'db'
   })
   .option('isSpamRestrictionMode', {
     type: 'boolean'
@@ -100,8 +114,12 @@ class WrkReportServiceApi extends WrkApi {
   init () {
     super.init()
 
+    const dbFolder = path.isAbsolute(argv.dbFolder)
+      ? argv.dbFolder
+      : path.join(this.ctx.root, argv.dbFolder)
     const dbId = this.ctx.dbId || argv.dbId || 1
     const opts = {
+      dbFolder,
       persist: true,
       name: `queue_${dbId}`
     }

--- a/workers/loc.api/logger/index.js
+++ b/workers/loc.api/logger/index.js
@@ -25,7 +25,10 @@ const isTestEnv = (
   process.env.NODE_ENV === 'test'
 )
 
-const basePath = '../../../logs'
+const rootPath = '../../..'
+const basePath = path.isAbsolute(argv.logsFolder)
+  ? argv.logsFolder
+  : path.join(rootPath, argv.logsFolder)
 const ext = '.log'
 
 const pathError = path.join(

--- a/workers/loc.api/logger/index.js
+++ b/workers/loc.api/logger/index.js
@@ -25,19 +25,17 @@ const isTestEnv = (
   process.env.NODE_ENV === 'test'
 )
 
-const rootPath = '../../..'
+const rootPath = path.join(__dirname, '../../..')
 const basePath = path.isAbsolute(argv.logsFolder)
   ? argv.logsFolder
   : path.join(rootPath, argv.logsFolder)
 const ext = '.log'
 
 const pathError = path.join(
-  __dirname,
   basePath,
   `errors-worker${ext}`
 )
 const pathExcLogger = path.join(
-  __dirname,
   basePath,
   `exceptions-worker${ext}`
 )

--- a/workers/loc.api/queue/helpers/utils.js
+++ b/workers/loc.api/queue/helpers/utils.js
@@ -47,7 +47,9 @@ const moveFileToLocalStorage = async (
   userInfo,
   isAddedUniqueEndingToCsvName
 ) => {
-  const localStorageDirPath = path.join(rootPath, argv.csvFolder || 'csv')
+  const localStorageDirPath = path.isAbsolute(argv.csvFolder)
+    ? argv.csvFolder
+    : path.join(rootPath, argv.csvFolder)
 
   await _checkAndCreateDir(localStorageDirPath)
 
@@ -83,7 +85,9 @@ const createUniqueFileName = async (rootPath, count = 0) => {
     throw new Error('ERR_CREATE_UNIQUE_FILE_NAME')
   }
 
-  const tempDirPath = path.join(rootPath, 'workers/loc.api/queue', 'temp')
+  const tempDirPath = path.isAbsolute(argv.tempFolder)
+    ? argv.tempFolder
+    : path.join(rootPath, argv.tempFolder)
 
   await _checkAndCreateDir(tempDirPath)
 


### PR DESCRIPTION
This PR adds an ability to specify paths to csv folder, temporary csv folder, logs folder, dbs of lokue queues

**Depends** on this PR [bfx-facs-lokue#3](https://github.com/bitfinexcom/bfx-facs-lokue/pull/3)