### PR TITLE
Add account summary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Reporting tool",
   "main": "worker.js",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bfx-facs-lokue": "git+https://github.com:bitfinexcom/bfx-facs-lokue.git",
     "bfx-svc-boot-js": "https://github.com/bitfinexcom/bfx-svc-boot-js.git",
     "bfx-wrk-api": "git+https://github.com/bitfinexcom/bfx-wrk-api.git",
-    "bitfinex-api-node": "^2.0.8",
+    "bitfinex-api-node": "^4.0.3",
     "colors": "^1.3.0",
     "csv": "^5.1.1",
     "inversify": "^5.0.1",

--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -1429,4 +1429,37 @@ describe('API', () => {
       'transactionId'
     ])
   })
+
+  it('it should be successfully performed by the getAccountSummary method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getAccountSummary',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.containsAllKeys(res.body.result, [
+      'time',
+      'status',
+      'is_locked',
+      'trade_vol_30d',
+      'fees_funding_30d',
+      'fees_funding_total_30d',
+      'fees_trading_30d',
+      'fees_trading_total_30d',
+      'maker_fee',
+      'taker_fee',
+      'deriv_maker_rebate',
+      'deriv_taker_fee'
+    ])
+  })
 })

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -462,5 +462,56 @@ module.exports = new Map([
         ]
       ]
     ]
+  ],
+  [
+    'account_summary',
+    [{
+      _id: '2a2a2a22222a2aa22a22aa2a',
+      user_id: 12345,
+      summary: {
+        time: '2020-02-10T06:49:30.270Z',
+        status: {
+          resid_hint: null
+        },
+        is_locked: false,
+        trade_vol_30d: [
+          {
+            curr: 'BTC',
+            vol: 0.12345
+          },
+          {
+            curr: 'ETH',
+            vol: 1.12345
+          },
+          {
+            curr: 'BTCF0',
+            vol: 0.12345
+          },
+          {
+            curr: 'Total (USD)',
+            vol: 12345.12345,
+            vol_maker: 12345.12345,
+            vol_BFX: 12345.12345,
+            vol_BFX_maker: 12345.12345
+          }
+        ],
+        fees_funding_30d: {
+          USD: 123.12345
+        },
+        fees_funding_total_30d: 123.12345,
+        fees_trading_30d: {
+          USTF0: 0.987654321,
+          ETH: 0.0012345,
+          USD: 1.987654321,
+          BTC: 0.000098765
+        },
+        fees_trading_total_30d: 1.12345,
+        maker_fee: 0.001,
+        taker_fee: 0.002,
+        deriv_maker_rebate: -0.0002,
+        deriv_taker_fee: 0.00098
+      },
+      t: 1581317371000
+    }]
   ]
 ])

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -400,6 +400,15 @@ class ReportService extends Api {
     }, 'getFundingCreditHistory', cb)
   }
 
+  getAccountSummary (space, args, cb) {
+    return this._responder(async () => {
+      const { auth } = { ...args }
+      const rest = this._getREST(auth)
+
+      return rest.accountSummary()
+    }, 'getAccountSummary', cb)
+  }
+
   getMultipleCsv (space, args, cb) {
     return this._responder(() => {
       return this._generateCsv(


### PR DESCRIPTION
This PR adds an account summary endpoint that always returns information from the api. Basic changes:
  - bumps `bitfinex-api-node` version up to `4.0.3`
  - adds `getAccountSummary` method to the main service
  - adds corresponding account summary test coverage
  - bumps version up to `2.2.2`

Example of request:
```json
{
    "auth": {
        "apiKey": "---",
        "apiSecret": "---"
    },
    "method": "getAccountSummary"
}
```

Example of response:
```json
{
    "result": {
        "time": "2020-02-10T06:49:30.270Z",
        "status": {
            "resid_hint": null
        },
        "is_locked": false,
        "trade_vol_30d": [
            {
                "curr": "BTC",
                "vol": 0.12345
            },
            {
                "curr": "ETH",
                "vol": 0.12345
            },
            {
                "curr": "BTCF0",
                "vol": 0.12345
            },
            {
                "curr": "Total (USD)",
                "vol": 12345.12345,
                "vol_maker": 12345.12345,
                "vol_BFX": 12345.12345,
                "vol_BFX_maker": 12345.12345
            }
        ],
        "fees_funding_30d": {
            "USD": 12345.12345
        },
        "fees_funding_total_30d": 12345.12345,
        "fees_trading_30d": {
            "USTF0": 0.12345,
            "ETH": 0.12345,
            "USD": 0.12345,
            "BTC": 0.12345
        },
        "fees_trading_total_30d": 4.12345,
        "maker_fee": 0.001,
        "taker_fee": 0.002,
        "deriv_maker_rebate": -0.0002,
        "deriv_taker_fee": 0.00111
    },
    "id": null
}
```

**Depends** on this PR: [bfx-api-mock-srv#28](https://github.com/bitfinexcom/bfx-api-mock-srv/pull/28)