### PR TITLE
Add logins

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Reporting tool",
   "main": "worker.js",
   "license": "Apache-2.0",

--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -1333,6 +1333,76 @@ describe('API', () => {
     assert.propertyVal(res.body, 'id', 5)
   })
 
+  it('it should be successfully performed by the getAccountSummary method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getAccountSummary',
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.containsAllKeys(res.body.result, [
+      'time',
+      'status',
+      'is_locked',
+      'trade_vol_30d',
+      'fees_funding_30d',
+      'fees_funding_total_30d',
+      'fees_trading_30d',
+      'fees_trading_total_30d',
+      'maker_fee',
+      'taker_fee',
+      'deriv_maker_rebate',
+      'deriv_taker_fee'
+    ])
+  })
+
+  it('it should be successfully performed by the getLogins method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getLogins',
+        params: {
+          start: 0,
+          end,
+          limit: 2
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isArray(res.body.result.res)
+    assert.isNumber(res.body.result.nextPage)
+
+    const resItem = res.body.result.res[0]
+
+    assert.isObject(resItem)
+    assert.containsAllKeys(resItem, [
+      'id',
+      'time',
+      'ip',
+      'extraData'
+    ])
+    assert.isObject(resItem.extraData)
+  })
+
   it('it should not be successfully performed by a fake method', async function () {
     this.timeout(5000)
 
@@ -1427,39 +1497,6 @@ describe('API', () => {
       'fees',
       'destinationAddress',
       'transactionId'
-    ])
-  })
-
-  it('it should be successfully performed by the getAccountSummary method', async function () {
-    this.timeout(5000)
-
-    const res = await agent
-      .post(`${basePath}/get-data`)
-      .type('json')
-      .send({
-        auth,
-        method: 'getAccountSummary',
-        id: 5
-      })
-      .expect('Content-Type', /json/)
-      .expect(200)
-
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.containsAllKeys(res.body.result, [
-      'time',
-      'status',
-      'is_locked',
-      'trade_vol_30d',
-      'fees_funding_30d',
-      'fees_funding_total_30d',
-      'fees_trading_30d',
-      'fees_trading_total_30d',
-      'maker_fee',
-      'taker_fee',
-      'deriv_maker_rebate',
-      'deriv_taker_fee'
     ])
   })
 })

--- a/test/4-queue-base.spec.js
+++ b/test/4-queue-base.spec.js
@@ -713,6 +713,32 @@ describe('Queue', () => {
     await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
+  it('it should be successfully performed by the getLoginsCsv method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/get-data`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getLoginsCsv',
+        params: {
+          end,
+          start,
+          limit: 1000,
+          email
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+  })
+
   it('it should not be successfully auth by the getLedgersCsv method', async function () {
     this.timeout(60000)
 

--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -39,6 +39,11 @@ const setDataTo = (
   const _date = Math.round(date)
 
   switch (key) {
+    case 'logins_hist':
+      dataItem[0] = id
+      dataItem[2] = _date
+      break
+
     case 'status_messages':
       dataItem[1] = _date
       dataItem[8] = _date
@@ -159,10 +164,12 @@ const getMockDataOpts = () => ({
   f_offer_hist: { limit: 500 },
   f_loan_hist: { limit: 500 },
   f_credit_hist: { limit: 500 },
+  logins_hist: { limit: 250 },
   user_info: null,
   symbols: null,
   futures: null,
-  currencies: null
+  currencies: null,
+  account_summary: null
 })
 
 const createMockRESTv2SrvWithDate = (

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -513,5 +513,29 @@ module.exports = new Map([
       },
       t: 1581317371000
     }]
+  ],
+  [
+    'logins_hist',
+    [[
+      12345,
+      null,
+      _ms,
+      null,
+      '127.0.0.1',
+      null,
+      null,
+      JSON.stringify({
+        asn: '14061, DigitalOcean, LLC',
+        geo: 'Unknown, SG',
+        user_agent: {
+          os: 'Linux x86_64',
+          raw: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36',
+          browser: 'Chrome',
+          version: '79.0.3945.130',
+          platform: 'X11',
+          is_mobile: false
+        }
+      })
+    ]]
   ]
 ])

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -823,6 +823,44 @@ class CsvJobData {
     return jobData
   }
 
+  async getLoginsCsvJobData (
+    args,
+    uId,
+    uInfo
+  ) {
+    checkParams(args)
+
+    const {
+      userId,
+      userInfo
+    } = await checkJobAndGetUserData(
+      this.rService,
+      args,
+      uId,
+      uInfo
+    )
+
+    const csvArgs = getCsvArgs(args, 'logins')
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getLogins',
+      args: csvArgs,
+      propNameForPagination: 'time',
+      columnsCsv: {
+        id: '#',
+        ip: 'IP',
+        time: 'DATE'
+      },
+      formatSettings: {
+        time: 'date'
+      }
+    }
+
+    return jobData
+  }
+
   async getMultipleCsvJobData (
     args,
     uId,

--- a/workers/loc.api/helpers/filter-models.js
+++ b/workers/loc.api/helpers/filter-models.js
@@ -204,5 +204,13 @@ module.exports = new Map([
       fundingAccrued: { type: 'number' },
       fundingStep: { type: 'number' }
     }
+  ],
+  [
+    FILTER_MODELS_NAMES.LOGINS,
+    {
+      id: { type: 'integer' },
+      time: { type: 'integer' },
+      ip: { type: 'string', format: 'ipv4' }
+    }
   ]
 ])

--- a/workers/loc.api/helpers/filter.models.names.js
+++ b/workers/loc.api/helpers/filter.models.names.js
@@ -22,5 +22,6 @@ module.exports = {
   FUNDING_OFFER_HISTORY: 'fundingOfferHistory',
   FUNDING_LOAN_HISTORY: 'fundingLoanHistory',
   FUNDING_CREDIT_HISTORY: 'fundingCreditHistory',
-  STATUS_MESSAGES: 'statusMessages'
+  STATUS_MESSAGES: 'statusMessages',
+  LOGINS: 'logins'
 }

--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -25,8 +25,9 @@ const {
   isNonceSmallError
 } = require('./api-errors-testers')
 const {
+  accountCache,
   parseFields,
-  accountCache
+  parseLoginsExtraDataFields
 } = require('./utils')
 const checkJobAndGetUserData = require(
   './check-job-and-get-user-data'
@@ -48,8 +49,9 @@ module.exports = {
   isAuthError,
   isRateLimitError,
   isNonceSmallError,
-  parseFields,
   accountCache,
+  parseFields,
+  parseLoginsExtraDataFields,
   getTimezoneConf,
   checkTimeLimit,
   prepareResponse,

--- a/workers/loc.api/helpers/limit-param.helpers.js
+++ b/workers/loc.api/helpers/limit-param.helpers.js
@@ -15,6 +15,7 @@ const getMethodLimit = (sendLimit, method, methodsLimits = {}) => {
     fundingOfferHistory: { default: 100, max: 500, innerMax: 500 },
     fundingLoanHistory: { default: 100, max: 500, innerMax: 500 },
     fundingCreditHistory: { default: 100, max: 500, innerMax: 500 },
+    logins: { default: 100, max: 250, innerMax: 250 },
     ...methodsLimits
   }
 

--- a/workers/loc.api/helpers/prepare-response.js
+++ b/workers/loc.api/helpers/prepare-response.js
@@ -36,6 +36,11 @@ const _paramsOrderMap = {
     'limit',
     'id'
   ],
+  logins: [
+    'start',
+    'end',
+    'limit'
+  ],
   default: [
     'symbol',
     'start',

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -3,6 +3,8 @@
 const { transform } = require('lodash')
 const LRU = require('lru')
 
+const accountCache = new LRU({ maxAge: 900000, max: 1 })
+
 const parseFields = (res, opts) => {
   const { executed, rate } = opts
 
@@ -18,9 +20,37 @@ const parseFields = (res, opts) => {
   }, [])
 }
 
-const accountCache = new LRU({ maxAge: 900000, max: 1 })
+const parseLoginsExtraDataFields = (res) => {
+  if (
+    !Array.isArray(res) ||
+    res.length === 0
+  ) {
+    return res
+  }
+
+  return res.map((item) => {
+    const { extraData } = { ...item }
+
+    if (
+      !extraData ||
+      typeof extraData !== 'string'
+    ) {
+      return item
+    }
+
+    try {
+      return {
+        ...item,
+        extraData: JSON.parse(extraData)
+      }
+    } catch (err) {
+      return item
+    }
+  })
+}
 
 module.exports = {
+  accountCache,
   parseFields,
-  accountCache
+  parseLoginsExtraDataFields
 }

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -5,6 +5,7 @@ const { Api } = require('bfx-wrk-api')
 const {
   checkParams,
   parseFields,
+  parseLoginsExtraDataFields,
   accountCache,
   getTimezoneConf,
   filterModels
@@ -407,6 +408,19 @@ class ReportService extends Api {
 
       return rest.accountSummary()
     }, 'getAccountSummary', cb)
+  }
+
+  getLogins (space, args, cb) {
+    return this._responder(() => {
+      return this._prepareApiResponse(
+        args,
+        'logins',
+        {
+          datePropName: 'time',
+          parseFieldsFn: parseLoginsExtraDataFields
+        }
+      )
+    }, 'getLogins', cb)
   }
 
   getMultipleCsv (space, args, cb) {

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -584,6 +584,15 @@ class ReportService extends Api {
       )
     }, 'getFundingCreditHistoryCsv', cb)
   }
+
+  getLoginsCsv (space, args, cb) {
+    return this._responder(() => {
+      return this._generateCsv(
+        'getLoginsCsvJobData',
+        args
+      )
+    }, 'getLoginsCsv', cb)
+  }
 }
 
 module.exports = ReportService


### PR DESCRIPTION
This PR adds a logins endpoint. Basic changes:
  - adds `getLogins` method to the main service
  - adds `getLoginsCsv` method to the main service
  - adds corresponding test coverage of logins
  - adds filter model for logins
  - bumps version up to `2.2.3`

Example of request:
```json
{
    "auth": {
        "apiKey": "---",
        "apiSecret": "---"
    },
    "method": "getLogins",
    "params": {
    	"end": 1575249855000,
    	"start": 1572566400000,
    	"limit": 2
    }
}
```

Example of response:
```json
{
    "result": {
        "res": [
            {
                "_isDataFromApiV2": true,
                "id": 12345,
                "time": 1575195432000,
                "ip": "127.0.0.1",
                "extraData": {
                    "asn": "12345, Google LLC",
                    "geo": "Unknown, SG",
                    "user_agent": {
                        "os": "Linux x86_64",
                        "raw": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.75 Safari/537.36",
                        "browser": "Chrome",
                        "version": "73.0.3683.75",
                        "platform": "X11",
                        "is_mobile": false
                    }
                }
            }
        ],
        "nextPage": 1575106836000
    },
    "id": null
}
```