### PR TITLE
Add funding and affiliate payments to hosted version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Reporting tool",
   "main": "worker.js",
   "license": "Apache-2.0",

--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -93,6 +93,12 @@ class FilterParamsValidSchemaFindingError extends ParamsValidSchemaFindingError 
   }
 }
 
+class LedgerPaymentFilteringParamsError extends ArgsParamsError {
+  constructor (message = 'ERR_FILTER_BY_MARGIN_AND_AFFILIATE_PARAMS_MAY_NOT_APPLY_TOGETHER') {
+    super(message)
+  }
+}
+
 module.exports = {
   BaseError,
   FindMethodError,
@@ -107,5 +113,6 @@ module.exports = {
   TimeframeError,
   ParamsValidSchemaFindingError,
   FilterParamsValidSchemaFindingError,
-  ArgsParamsFilterError
+  ArgsParamsFilterError,
+  LedgerPaymentFilteringParamsError
 }


### PR DESCRIPTION
This PR adds an ability to filter ledgers by funding and affiliate payments to the hosted version:

  - Example of request:
```js
{
    "auth": {
        "apiKey": "---",
        "apiSecret": "---"
    },
    "method": "getLedgers",
    "params": {
    	"end": 1575249855000,
    	"start": 1572566400000,
    	"limit": 2,
        "symbol": "USD",
    	"isMarginFundingPayment": true // or "isAffiliateRebate": true
    }
}
```

  - Example of response:
```json
{
    "result": {
        "res": [
            {
                "id": 123456789,
                "currency": "USD",
                "mts": 1575163809000,
                "amount": 1.2345,
                "amountUsd": 5.4321,
                "balance": 12345.12345,
                "balanceUsd": 54321.54321,
                "description": "Margin Funding Payment on wallet funding",
                "wallet": "funding"
            }
        ],
        "nextPage": false
    },
    "id": null
}
```