### PR TITLE
Return account summary array instead of object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report",
-  "version": "2.2.6",
+  "version": "3.0.0",
   "description": "Reporting tool",
   "main": "worker.js",
   "license": "Apache-2.0",

--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -1387,21 +1387,26 @@ describe('API', () => {
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
-    assert.isObject(res.body.result)
-    assert.containsAllKeys(res.body.result, [
-      'time',
-      'status',
-      'is_locked',
-      'trade_vol_30d',
-      'fees_funding_30d',
-      'fees_funding_total_30d',
-      'fees_trading_30d',
-      'fees_trading_total_30d',
-      'maker_fee',
-      'taker_fee',
-      'deriv_maker_rebate',
-      'deriv_taker_fee'
-    ])
+    assert.isArray(res.body.result)
+    assert.lengthOf(res.body.result, 1)
+
+    res.body.result.forEach((res) => {
+      assert.isObject(res)
+      assert.containsAllKeys(res, [
+        'time',
+        'status',
+        'is_locked',
+        'trade_vol_30d',
+        'fees_funding_30d',
+        'fees_funding_total_30d',
+        'fees_trading_30d',
+        'fees_trading_total_30d',
+        'maker_fee',
+        'taker_fee',
+        'deriv_maker_rebate',
+        'deriv_taker_fee'
+      ])
+    })
   })
 
   it('it should be successfully performed by the getLogins method', async function () {

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -432,7 +432,9 @@ class ReportService extends Api {
       const { auth } = { ...args }
       const rest = this._getREST(auth)
 
-      return rest.accountSummary()
+      const res = await rest.accountSummary()
+
+      return Array.isArray(res) ? res : [res]
     }, 'getAccountSummary', cb)
   }
 


### PR DESCRIPTION
This PR adds an ability to return account summary array instead of an object. This is required for sub-accounts to return an array of objects of all sub-users related to sub-account