### PR TITLE
Remove redundant test coverage of wallets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "Reporting tool",
   "main": "worker.js",
   "license": "Apache-2.0",

--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -422,40 +422,6 @@ describe('API', () => {
     ])
   })
 
-  it('it should be successfully performed by the getWallets method', async function () {
-    this.timeout(5000)
-
-    const res = await agent
-      .post(`${basePath}/get-data`)
-      .type('json')
-      .send({
-        auth,
-        method: 'getWallets',
-        params: {
-          end
-        },
-        id: 5
-      })
-      .expect('Content-Type', /json/)
-      .expect(200)
-
-    assert.isObject(res.body)
-    assert.propertyVal(res.body, 'id', 5)
-    assert.isArray(res.body.result)
-
-    const resItem = res.body.result[0]
-
-    assert.isObject(resItem)
-    assert.containsAllKeys(resItem, [
-      'type',
-      'currency',
-      'balance',
-      'unsettledInterest',
-      'balanceAvailable',
-      'mtsUpdate'
-    ])
-  })
-
   it('it should be successfully performed by the getWallets method, without params', async function () {
     this.timeout(5000)
 

--- a/test/4-queue-base.spec.js
+++ b/test/4-queue-base.spec.js
@@ -263,7 +263,6 @@ describe('Queue', () => {
         auth,
         method: 'getWalletsCsv',
         params: {
-          end,
           email
         },
         id: 5

--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -57,10 +57,6 @@ const setDataTo = (
       dataItem[15] = _date
       break
 
-    case 'wallets_hist':
-      dataItem[6] = _date
-      break
-
     case 'positions_hist':
       dataItem[11] = id
       dataItem[12] = _date
@@ -151,7 +147,6 @@ const setDataTo = (
 
 const getMockDataOpts = () => ({
   tickers_hist: { limit: 250 },
-  wallets_hist: { limit: 100, isNotMoreThanLimit: true },
   wallets: { limit: 100, isNotMoreThanLimit: true },
   positions_hist: { limit: 50 },
   positions: { limit: 50 },

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -71,18 +71,6 @@ module.exports = new Map([
     ]]
   ],
   [
-    'wallets_hist',
-    [[
-      'margin',
-      'BTC',
-      -0.04509854,
-      null,
-      null,
-      null,
-      _ms
-    ]]
-  ],
-  [
     'positions_hist',
     [[
       'tBTCUSD',


### PR DESCRIPTION
This PR removes redundant test coverage of the `getWallets` endpoint
These changes are related to this PR [bfx-report#171](https://github.com/bitfinexcom/bfx-report/pull/171)