### PR TITLE
Add changeLogs endpoint

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -1408,6 +1408,42 @@ describe('API', () => {
     assert.isObject(resItem.extraData)
   })
 
+  it('it should be successfully performed by the getChangeLogs method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getChangeLogs',
+        params: {
+          start: 0,
+          end,
+          limit: 2
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isArray(res.body.result.res)
+    assert.isNumber(res.body.result.nextPage)
+
+    const resItem = res.body.result.res[0]
+
+    assert.isObject(resItem)
+    assert.containsAllKeys(resItem, [
+      'mtsCreate',
+      'log',
+      'ip',
+      'userAgent'
+    ])
+  })
+
   it('it should not be successfully performed by a fake method', async function () {
     this.timeout(5000)
 

--- a/test/4-queue-base.spec.js
+++ b/test/4-queue-base.spec.js
@@ -766,6 +766,32 @@ describe('Queue', () => {
     await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
+  it('it should be successfully performed by the getChangeLogsCsv method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getChangeLogsCsv',
+        params: {
+          end,
+          start,
+          limit: 1000,
+          email
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+  })
+
   it('it should not be successfully auth by the getLedgersCsv method', async function () {
     this.timeout(60000)
 

--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -43,6 +43,10 @@ const setDataTo = (
       dataItem[0] = _date
       break
 
+    case 'change_log':
+      dataItem[0] = _date
+      break
+
     case 'logins_hist':
       dataItem[0] = id
       dataItem[2] = _date
@@ -164,6 +168,7 @@ const getMockDataOpts = () => ({
   f_loan_hist: { limit: 500 },
   f_credit_hist: { limit: 500 },
   logins_hist: { limit: 250 },
+  change_log: { limit: 500 },
   candles: { limit: 500 },
   user_info: null,
   symbols: null,

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -527,6 +527,18 @@ module.exports = new Map([
     ]]
   ],
   [
+    'change_log',
+    [[
+      _ms,
+      null,
+      'settings: timezone',
+      null,
+      null,
+      '127.0.0.1',
+      'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36'
+    ]]
+  ],
+  [
     'candles',
     [[
       _ms,

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -887,6 +887,44 @@ class CsvJobData {
     return jobData
   }
 
+  async getChangeLogsCsvJobData (
+    args,
+    uId,
+    uInfo
+  ) {
+    checkParams(args)
+
+    const {
+      userId,
+      userInfo
+    } = await checkJobAndGetUserData(
+      this.rService,
+      uId,
+      uInfo
+    )
+
+    const csvArgs = getCsvArgs(args, 'changeLogs')
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getChangeLogs',
+      args: csvArgs,
+      propNameForPagination: 'mtsCreate',
+      columnsCsv: {
+        mtsCreate: 'DATE',
+        log: 'LOG',
+        ip: 'IP',
+        userAgent: 'USER AGENT'
+      },
+      formatSettings: {
+        time: 'mtsCreate'
+      }
+    }
+
+    return jobData
+  }
+
   async getMultipleCsvJobData (
     args,
     uId,

--- a/workers/loc.api/helpers/filter-models.js
+++ b/workers/loc.api/helpers/filter-models.js
@@ -214,6 +214,15 @@ module.exports = new Map([
     }
   ],
   [
+    FILTER_MODELS_NAMES.CHANGE_LOGS,
+    {
+      mtsCreate: { type: 'integer' },
+      log: { type: 'string' },
+      ip: { type: 'string', format: 'ipv4' },
+      userAgent: { type: 'string' }
+    }
+  ],
+  [
     FILTER_MODELS_NAMES.CANDLES,
     {
       mts: { type: 'integer' },

--- a/workers/loc.api/helpers/filter.models.names.js
+++ b/workers/loc.api/helpers/filter.models.names.js
@@ -24,5 +24,6 @@ module.exports = {
   FUNDING_CREDIT_HISTORY: 'fundingCreditHistory',
   STATUS_MESSAGES: 'statusMessages',
   LOGINS: 'logins',
+  CHANGE_LOGS: 'changeLogs',
   CANDLES: 'candles'
 }

--- a/workers/loc.api/helpers/limit-param.helpers.js
+++ b/workers/loc.api/helpers/limit-param.helpers.js
@@ -17,6 +17,7 @@ const getMethodLimit = (sendLimit, method, methodsLimits = {}) => {
     fundingCreditHistory: { default: 100, max: 500, innerMax: 500 },
     logins: { default: 100, max: 250, innerMax: 250 },
     candles: { default: 500, max: 500, innerMax: 10000 },
+    changeLogs: { default: 500, max: 500, innerMax: 500 },
     ...methodsLimits
   }
 

--- a/workers/loc.api/helpers/prepare-response.js
+++ b/workers/loc.api/helpers/prepare-response.js
@@ -45,6 +45,11 @@ const _paramsOrderMap = {
     'end',
     'limit'
   ],
+  changeLogs: [
+    'start',
+    'end',
+    'limit'
+  ],
   default: [
     'symbol',
     'start',

--- a/workers/loc.api/queue/helpers/get-complete-file-name.js
+++ b/workers/loc.api/queue/helpers/get-complete-file-name.js
@@ -20,7 +20,9 @@ const _fileNamesMap = new Map([
   ['getPositionsAudit', 'positions_audit'],
   ['getWallets', 'wallets'],
   ['getTickersHistory', 'tickers_history'],
-  ['getActivePositions', 'active_positions']
+  ['getActivePositions', 'active_positions'],
+  ['getLogins', 'logins'],
+  ['getChangeLogs', 'change_logs']
 ])
 
 const _getBaseName = (

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -649,6 +649,15 @@ class ReportService extends Api {
       )
     }, 'getLoginsCsv', cb)
   }
+
+  getChangeLogsCsv (space, args, cb) {
+    return this._responder(() => {
+      return this._generateCsv(
+        'getChangeLogsCsvJobData',
+        args
+      )
+    }, 'getChangeLogsCsv', cb)
+  }
 }
 
 module.exports = ReportService

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -458,6 +458,18 @@ class ReportService extends Api {
     }, 'getLogins', cb)
   }
 
+  changeLogs (space, args, cb) {
+    return this._responder(() => {
+      return this._prepareApiResponse(
+        args,
+        'changeLogs',
+        {
+          datePropName: 'mtsCreate'
+        }
+      )
+    }, 'changeLogs', cb)
+  }
+
   getMultipleCsv (space, args, cb) {
     return this._responder(() => {
       return this._generateCsv(

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -458,7 +458,7 @@ class ReportService extends Api {
     }, 'getLogins', cb)
   }
 
-  changeLogs (space, args, cb) {
+  getChangeLogs (space, args, cb) {
     return this._responder(() => {
       return this._prepareApiResponse(
         args,
@@ -467,7 +467,7 @@ class ReportService extends Api {
           datePropName: 'mtsCreate'
         }
       )
-    }, 'changeLogs', cb)
+    }, 'getChangeLogs', cb)
   }
 
   getMultipleCsv (space, args, cb) {


### PR DESCRIPTION
This PR adds changeLogs endpoints. Basic changes:
  - adds `getChangeLogs` method to the main service
  - adds `getChangeLogsCsv` method to the main service
  - adds corresponding test coverage

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-report/pull/174