### PR TITLE
Add inactive symbols

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -230,8 +230,10 @@ describe('API', () => {
     assert.isObject(res.body.result)
     assert.isArray(res.body.result.pairs)
     assert.isArray(res.body.result.currencies)
+    assert.isArray(res.body.result.inactiveSymbols)
     assert.lengthOf(res.body.result.pairs, 13)
     assert.lengthOf(res.body.result.currencies, 11)
+    assert.lengthOf(res.body.result.inactiveSymbols, 2)
 
     res.body.result.pairs.forEach(item => {
       assert.isString(item)

--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -167,6 +167,7 @@ const getMockDataOpts = () => ({
   candles: { limit: 500 },
   user_info: null,
   symbols: null,
+  inactive_symbols: null,
   futures: null,
   currencies: null,
   account_summary: null

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -20,6 +20,13 @@ module.exports = new Map([
     ]]
   ],
   [
+    'inactive_symbols',
+    [[
+      'GRGETH',
+      'GRGBTC'
+    ]]
+  ],
+  [
     'futures',
     [[
       'BTCF0:USDF0',

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -48,6 +48,12 @@ class ReportService extends Api {
     return rest.currencies()
   }
 
+  _getInactiveSymbols () {
+    const rest = this._getREST({})
+
+    return rest.inactiveSymbols()
+  }
+
   getFilterModels (space, args, cb) {
     return this._responder(() => {
       const models = [...filterModels]
@@ -130,12 +136,20 @@ class ReportService extends Api {
 
       if (cache) return cache
 
-      const symbols = await this._getSymbols()
-      const futures = await this._getFutures()
-      const pairs = [...symbols, ...futures]
+      const [
+        symbols,
+        futures,
+        currencies,
+        inactiveSymbols
+      ] = await Promise.all([
+        this._getSymbols(),
+        this._getFutures(),
+        this._getCurrencies(),
+        this._getInactiveSymbols()
+      ])
 
-      const currencies = await this._getCurrencies()
-      const res = { pairs, currencies }
+      const pairs = [...symbols, ...futures]
+      const res = { pairs, currencies, inactiveSymbols }
 
       accountCache.set('symbols', res)
 


### PR DESCRIPTION
This PR adds inactive symbols https://github.com/bitfinexcom/bfx-api-node-rest/pull/70 to `getSymbols` method

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-report/pull/174
  - https://github.com/bitfinexcom/bfx-api-mock-srv/pull/36