### PR TITLE
Add mock data for currency walletFx

### DIFF
--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -455,6 +455,26 @@ module.exports = new Map([
             'https://etherscan.io/tx/VAL'
           ]
         ]
+      ],
+      [
+        [
+          'LET',
+          [
+            [
+              'LEO',
+              1
+            ]
+          ]
+        ],
+        [
+          'LBT',
+          [
+            [
+              'BTC',
+              1
+            ]
+          ]
+        ]
       ]
     ]
   ],


### PR DESCRIPTION
This PR adds mock data for currency `walletFx` field

**Depends** on these PRs:
  - https://github.com/bitfinexcom/bfx-api-node-models/pull/53
  - https://github.com/bitfinexcom/bfx-api-node-rest/pull/72