### PR TITLE
Remove check-stored-locally endpoint

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -172,25 +172,6 @@ describe('API', () => {
     assert.propertyVal(res.body, 'id', null)
   })
 
-  it('it should be successfully check, csv is stored locally', async function () {
-    this.timeout(5000)
-
-    const res = await agent
-      .post(`${basePath}/check-stored-locally`)
-      .type('json')
-      .send({
-        auth,
-        id: 5
-      })
-      .expect('Content-Type', /json/)
-      .expect(200)
-
-    assert.isObject(res.body)
-    assert.isString(res.body.result)
-    assert.strictEqual(res.body.result, 'fake@email.fake')
-    assert.propertyVal(res.body, 'id', 5)
-  })
-
   it('it should be successfully performed by the getUsersTimeConf method', async function () {
     this.timeout(5000)
 

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -11,10 +11,7 @@ const {
   filterModels,
   parsePositionsAuditId
 } = require('./helpers')
-const {
-  ArgsParamsError,
-  AuthError
-} = require('./errors')
+const { AuthError } = require('./errors')
 const TYPES = require('./di/types')
 
 class ReportService extends Api {
@@ -113,21 +110,6 @@ class ReportService extends Api {
 
       return getTimezoneConf(timezone)
     }, 'getUsersTimeConf', cb)
-  }
-
-  lookUpFunction (space, args, cb) {
-    return this._responder(() => {
-      if (
-        !args.params ||
-        typeof args.params !== 'object'
-      ) {
-        throw new ArgsParamsError()
-      }
-
-      const { service } = { ...args.params }
-
-      return this._hasGrcService.lookUpFunction(service)
-    }, 'lookUpFunction', cb)
   }
 
   getSymbols (space, args, cb) {


### PR DESCRIPTION
This PR removes `/check-stored-locally` endpoint supporting

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-report-express/pull/11