### PR TITLE
Reduce response payload

### DIFF
--- a/workers/loc.api/helpers/prepare-response.js
+++ b/workers/loc.api/helpers/prepare-response.js
@@ -408,7 +408,8 @@ const _omitPrivateModelFields = (res) => {
     '_eventsCount',
     '_fields',
     '_boolFields',
-    '_fieldKeys'
+    '_fieldKeys',
+    '_apiInterface'
   ]
 
   if (


### PR DESCRIPTION
This PR reduces the response payload. The issue is in response of the `getPositionsAudit` method was noticed redundant `_apiInterface` object which one is proxied from the `bitfinex-api-node`:

```json
"_apiInterface": {
  "_url": "https://api-pub.bitfinex.com",
  "_apiKey": "---",
  "_apiSecret": "---",
  "_authToken": "",
  "_company": "bitfinex",
  "_transform": true,
  "_rest1": {
      "_url": "https://api-pub.bitfinex.com",
      "_apiKey": "---",
      "_apiSecret": "---"
  }
}
```