### PR TITLE
Fix csv export with searching by filter

### DIFF
--- a/workers/loc.api/queue/write-data-to-stream/index.js
+++ b/workers/loc.api/queue/write-data-to-stream/index.js
@@ -74,7 +74,7 @@ module.exports = (
       res.length === 0 &&
       nextPage &&
       Number.isInteger(nextPage) &&
-      serialRequestsCount < 1
+      serialRequestsCount < 1000
     ) {
       serialRequestsCount += 1
 


### PR DESCRIPTION
This PR fixes csv export with searching by a filter when the first responses are empty