### PR TITLE
Add min and max clamps to status messages derivatives

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -954,7 +954,9 @@ describe('API', () => {
       'priceSpot',
       'fundBal',
       'fundingAccrued',
-      'fundingStep'
+      'fundingStep',
+      'clampMin',
+      'clampMax'
     ])
   })
 

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -200,7 +200,18 @@ module.exports = new Map([
       -0.00019831,
       5534,
       null,
-      0.0006622
+      0.0006622,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      12345,
+      54321
     ]]
   ],
   [

--- a/workers/loc.api/helpers/filter-models.js
+++ b/workers/loc.api/helpers/filter-models.js
@@ -202,7 +202,9 @@ module.exports = new Map([
       priceSpot: { type: 'number' },
       fundBal: { type: 'number' },
       fundingAccrued: { type: 'number' },
-      fundingStep: { type: 'number' }
+      fundingStep: { type: 'number' },
+      clampMin: { type: 'number' },
+      clampMax: { type: 'number' }
     }
   ],
   [


### PR DESCRIPTION
This PR adds `clampMin` and `clampMax` fields to status messages derivatives. Basic changes:
  - adds filtering fields to status messages derivatives
  - improves status messages derivatives test coverage
  - improves test helper for removing db files

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-api-node-models/pull/57