### PR TITLE
Add ability to generate auth token

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -94,6 +94,31 @@ describe('API', () => {
     assert.propertyVal(res.body, 'id', 5)
   })
 
+  it('it should be successfully performed by the generateToken method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        method: 'generateToken',
+        auth,
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isArray(res.body.result)
+    assert.lengthOf(res.body.result, 1)
+
+    res.body.result.forEach((token) => {
+      assert.isString(token)
+      assert.strictEqual(token, 'pub:api:12ab12ab-12ab-12ab-12ab-12ab12ab12ab-read')
+    })
+  })
+
   it('it should be successfully performed by the getFilterModels method', async function () {
     this.timeout(5000)
 

--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -177,7 +177,8 @@ const getMockDataOpts = () => ({
   currencies: null,
   account_summary: null,
   get_settings: null,
-  set_settings: null
+  set_settings: null,
+  generate_token: null
 })
 
 const createMockRESTv2SrvWithDate = (

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -606,5 +606,11 @@ module.exports = new Map([
       'SUCCESS',
       null
     ]
+  ],
+  [
+    'generate_token',
+    [
+      'pub:api:12ab12ab-12ab-12ab-12ab-12ab12ab12ab-read'
+    ]
   ]
 ])

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -104,6 +104,20 @@ class ReportService extends Api {
     }, 'verifyUser', cb)
   }
 
+  generateToken (space, args, cb) {
+    return this._responder(async () => {
+      const { auth } = { ...args }
+      const rest = this._getREST(auth)
+
+      return rest.generateToken({
+        ttl: 3600,
+        scope: 'api',
+        writePermission: false,
+        _cust_ip: '0'
+      })
+    }, 'verifyUser', cb)
+  }
+
   getUsersTimeConf (space, args, cb) {
     return this._responder(async () => {
       const { timezone } = await this._getUserInfo(args)


### PR DESCRIPTION
This PR adds the ability to generate an auth token. Basic changes:
  - adds `generateToken` method to the main service
  - adds corresponding test coverage

Request example:
```json
{
    "auth": {
        "apiKey": "---",
        "apiSecret": "---"
    },
    "method": "generateToken"
}
```

Response example:
```json
{
    "result": [
        "pub:api:12ab12ab-12ab-12ab-12ab-12ab12ab12ab-read"
    ],
    "id": null
}
```

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-api-mock-srv/pull/41