### PR TITLE
Add ability to fetch positions snapshot

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -393,6 +393,51 @@ describe('API', () => {
     ])
   })
 
+  it('it should be successfully performed by the getPositionsSnapshot method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getPositionsSnapshot',
+        params: {
+          start: 0,
+          end,
+          limit: 2
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isArray(res.body.result.res)
+    assert.isNumber(res.body.result.nextPage)
+
+    const resItem = res.body.result.res[0]
+
+    assert.isObject(resItem)
+    assert.containsAllKeys(resItem, [
+      'symbol',
+      'status',
+      'amount',
+      'basePrice',
+      'marginFunding',
+      'marginFundingType',
+      'pl',
+      'plPerc',
+      'liquidationPrice',
+      'leverage',
+      'id',
+      'mtsCreate',
+      'mtsUpdate'
+    ])
+  })
+
   it('it should be successfully performed by the getActivePositions method', async function () {
     this.timeout(5000)
 

--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -61,6 +61,12 @@ const setDataTo = (
       dataItem[15] = _date
       break
 
+    case 'positions_snap':
+      dataItem[11] = id
+      dataItem[12] = _date
+      dataItem[13] = _date
+      break
+
     case 'positions_hist':
       dataItem[11] = id
       dataItem[12] = _date
@@ -153,6 +159,7 @@ const getMockDataOpts = () => ({
   tickers_hist: { limit: 250 },
   wallets: { limit: 100, isNotMoreThanLimit: true },
   positions_hist: { limit: 50 },
+  positions_snap: { limit: 50 },
   positions: { limit: 50 },
   positions_audit: { limit: 250 },
   ledgers: { limit: 500 },

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -78,6 +78,25 @@ module.exports = new Map([
     ]]
   ],
   [
+    'positions_snap',
+    [[
+      'tBTCUSD',
+      'ACTIVE',
+      0.1,
+      16500,
+      0,
+      0,
+      null,
+      null,
+      null,
+      null,
+      null,
+      12345,
+      _ms,
+      _ms
+    ]]
+  ],
+  [
     'positions_hist',
     [[
       'tBTCUSD',

--- a/workers/loc.api/di/index.js
+++ b/workers/loc.api/di/index.js
@@ -3,4 +3,4 @@
 require('reflect-metadata')
 const { Container } = require('inversify')
 
-module.exports = new Container()
+module.exports = new Container({ skipBaseClassChecks: true })

--- a/workers/loc.api/helpers/check-filter-params.js
+++ b/workers/loc.api/helpers/check-filter-params.js
@@ -102,7 +102,10 @@ const _getFilterSchema = (model = {}) => {
 }
 
 const _getMethodApiName = (methodApi) => {
-  if (methodApi === FILTER_MODELS_NAMES.POSITIONS_AUDIT) {
+  if (
+    methodApi === FILTER_MODELS_NAMES.POSITIONS_AUDIT ||
+    methodApi === FILTER_MODELS_NAMES.POSITIONS_SNAPSHOT
+  ) {
     return FILTER_MODELS_NAMES.POSITIONS_HISTORY
   }
   if (methodApi === FILTER_MODELS_NAMES.ORDER_TRADES) {

--- a/workers/loc.api/helpers/filter.models.names.js
+++ b/workers/loc.api/helpers/filter.models.names.js
@@ -7,6 +7,10 @@ module.exports = {
   /**
    * It's an alias to POSITIONS_HISTORY model
    */
+  POSITIONS_SNAPSHOT: 'positionsSnapshot',
+  /**
+   * It's an alias to POSITIONS_HISTORY model
+   */
   POSITIONS_AUDIT: 'positionsAudit',
   LEDGERS: 'ledgers',
   TRADES: 'trades',

--- a/workers/loc.api/helpers/limit-param.helpers.js
+++ b/workers/loc.api/helpers/limit-param.helpers.js
@@ -18,6 +18,7 @@ const getMethodLimit = (sendLimit, method, methodsLimits = {}) => {
     logins: { default: 100, max: 250, innerMax: 250 },
     candles: { default: 500, max: 500, innerMax: 10000 },
     changeLogs: { default: 500, max: 500, innerMax: 500 },
+    positionsSnapshot: { default: 50, max: 500, innerMax: 500 },
     ...methodsLimits
   }
 

--- a/workers/loc.api/helpers/prepare-response.js
+++ b/workers/loc.api/helpers/prepare-response.js
@@ -19,6 +19,11 @@ const {
 } = require('../errors')
 
 const _paramsOrderMap = {
+  positionsSnapshot: [
+    'start',
+    'end',
+    'limit'
+  ],
   statusMessages: [
     'type',
     'symbol'

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -51,6 +51,19 @@ class ReportService extends Api {
     return rest.inactiveSymbols()
   }
 
+  getPositionsSnapshot (space, args, cb) {
+    return this._responder(() => {
+      return this._prepareApiResponse(
+        args,
+        'positionsSnapshot',
+        {
+          datePropName: 'mtsUpdate',
+          symbPropName: 'symbol'
+        }
+      )
+    }, 'getPositionsSnapshot', cb)
+  }
+
   getFilterModels (space, args, cb) {
     return this._responder(() => {
       const models = [...filterModels]


### PR DESCRIPTION
This PR adds the ability to fetch positions snapshot from the API to sync in the framework part for `win/loss` section. Basic changes:
  - adds `getPositionsSnapshot` method to the main service
  - adds the corresponding test coverage
  - fixes DI (`InversifyJS`) base class checks issue:
https://github.com/inversify/InversifyJS/issues/522
https://github.com/inversify/InversifyJS/blob/master/wiki/inheritance.md#workaround-e-skip-base-class-injectable-checks