### PR TITLE
Add map symbols and inactive currencies into getSymbols

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -240,7 +240,12 @@ describe('API', () => {
     assert.lengthOf(res.body.result.pairs, 13)
     assert.lengthOf(res.body.result.currencies, 11)
     assert.lengthOf(res.body.result.inactiveSymbols, 2)
+    assert.lengthOf(res.body.result.mapSymbols, 3)
+    assert.lengthOf(res.body.result.inactiveCurrencies, 2)
 
+    res.body.result.mapSymbols.forEach(item => {
+      assert.lengthOf(item, 2)
+    })
     res.body.result.pairs.forEach(item => {
       assert.isString(item)
     })

--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -179,6 +179,8 @@ const getMockDataOpts = () => ({
   candles: { limit: 500 },
   user_info: null,
   symbols: null,
+  map_symbols: null,
+  inactive_currencies: null,
   inactive_symbols: null,
   futures: null,
   currencies: null,

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -20,6 +20,21 @@ module.exports = new Map([
     ]]
   ],
   [
+    'map_symbols',
+    [[
+      ['BTCF0:USTF0', 'BTC-PERP'],
+      ['ETHF0:BTCF0', 'ETH:BTC-PERP'],
+      ['EURF0:USTF0', 'EUR/USDt-PERP']
+    ]]
+  ],
+  [
+    'inactive_currencies',
+    [[
+      'TTT',
+      'DDD'
+    ]]
+  ],
+  [
     'inactive_symbols',
     [[
       'GRGETH',

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -51,6 +51,32 @@ class ReportService extends Api {
     return rest.inactiveSymbols()
   }
 
+  async _getConf (opts) {
+    const { keys } = { ...opts }
+    const _keys = Array.isArray(keys) ? keys : [keys]
+    const rest = this._getREST({})
+
+    const res = await rest.conf(_keys)
+
+    return Array.isArray(res) ? res : []
+  }
+
+  async _getMapSymbols () {
+    const [res] = await this._getConf({
+      keys: 'pub:map:pair:sym'
+    })
+
+    return Array.isArray(res) ? res : []
+  }
+
+  async _getInactiveCurrencies () {
+    const [res] = await this._getConf({
+      keys: 'pub:list:currency:inactive'
+    })
+
+    return Array.isArray(res) ? res : []
+  }
+
   getPositionsSnapshot (space, args, cb) {
     return this._responder(() => {
       return this._prepareApiResponse(
@@ -149,16 +175,26 @@ class ReportService extends Api {
         symbols,
         futures,
         currencies,
-        inactiveSymbols
+        inactiveSymbols,
+        mapSymbols,
+        inactiveCurrencies
       ] = await Promise.all([
         this._getSymbols(),
         this._getFutures(),
         this._getCurrencies(),
-        this._getInactiveSymbols()
+        this._getInactiveSymbols(),
+        this._getMapSymbols(),
+        this._getInactiveCurrencies()
       ])
 
       const pairs = [...symbols, ...futures]
-      const res = { pairs, currencies, inactiveSymbols }
+      const res = {
+        pairs,
+        currencies,
+        inactiveSymbols,
+        mapSymbols,
+        inactiveCurrencies
+      }
 
       accountCache.set('symbols', res)
 


### PR DESCRIPTION
This PR adds map symbols and inactive currencies into the response of the `getSymbols` method, adds the corresponding test coverage.

Example of request:
```json
{
    "method": "getSymbols"
}
```

Example of response:
```json
{
    "result": {
        "pairs": [
            "AMPUSD",
            "BCCUSD"
        ],
        "currencies": [
            {
                "id": "AMP",
                "name": "Ampleforth",
                "pool": "ETH",
                "explorer": [
                    "https://etherscan.io",
                    "https://etherscan.io/address/VAL",
                    "https://etherscan.io/tx/VAL"
                ],
                "symbol": "AMPL",
                "walletFx": []
            }
        ],
        "inactiveSymbols": [
            "GRGETH"
        ],
        "mapSymbols": [
            [
                "BTCF0:USTF0",
                "BTC-PERP"
            ],
            [
                "ETHF0:BTCF0",
                "ETH:BTC-PERP"
            ]
        ],
        "inactiveCurrencies": [
            "TTT",
            "DDD"
        ]
    },
    "id": null
}
```

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-api-mock-srv/pull/43