### PR TITLE
Fix nonce small error issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "reflect-metadata": "^0.1.13",
     "uuid": "^3.3.2",
     "winston": "^3.1.0",
-    "yargs": "^13.2.4"
+    "yargs": "^16.2.0"
   },
   "devDependencies": {
     "bfx-report-express": "git+https://github.com/bitfinexcom/bfx-report-express.git",


### PR DESCRIPTION
This PR fixes the nonce small error issues. The issue is related to the following points:
  - for each request should be generated and added a new nonce for usage with the Bitfinex APIs. The nonce must be increased for the next request either an error will be thrown. This solution works fine:
https://github.com/bitfinexcom/bfx-api-node-util/blob/master/lib/nonce.js
  - but we can have situations when the app can send sequential requests one by one, for example
```
1 - request with nonce: 1611303213479000 - slow
2 - request with nonce: 1611303213479001
3 - request with nonce: 1611303213479002 - fast
```
and when `1 - request` perform slower than `3 - request` and the bfx API perform `3 - request` and store its nonce, at this case we can catch the nonce error for `1 - request`

This solution adds the ability to do several attempts for each call of the bfx API when the nonce error occurs

Updates `yargs` dep to fix the low vulnerability:
https://www.npmjs.com/advisories/1500