### PR TITLE
Add helper to decorate injectable class

### DIFF
--- a/workers/loc.api/di/utils/decorate-injectable.js
+++ b/workers/loc.api/di/utils/decorate-injectable.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const {
+  decorate,
+  injectable,
+  inject
+} = require('inversify')
+
+const _TYPES = require('../types')
+
+module.exports = (
+  ModuleClass,
+  getDepsTypesFn,
+  TYPES = _TYPES
+) => {
+  decorate(injectable(), ModuleClass)
+
+  const depsTypes = typeof getDepsTypesFn === 'function'
+    ? getDepsTypesFn(TYPES)
+    : getDepsTypesFn
+
+  if (!Array.isArray(depsTypes)) {
+    return ModuleClass
+  }
+
+  for (const [i, depsType] of depsTypes.entries()) {
+    decorate(inject(depsType), ModuleClass, i)
+  }
+
+  return ModuleClass
+}

--- a/workers/loc.api/di/utils/index.js
+++ b/workers/loc.api/di/utils/index.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const decorateInjectable = require('./decorate-injectable')
+
+module.exports = {
+  decorateInjectable
+}

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -1,12 +1,6 @@
 'use strict'
 
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
-
-const TYPES = require('../di/types')
+const { decorateInjectable } = require('../di/utils')
 
 const {
   checkParams,
@@ -20,6 +14,9 @@ const {
   SymbolsTypeError
 } = require('../errors')
 
+const depsTypes = (TYPES) => [
+  TYPES.RService
+]
 class CsvJobData {
   constructor (rService) {
     this.rService = rService
@@ -981,7 +978,6 @@ class CsvJobData {
   }
 }
 
-decorate(injectable(), CsvJobData)
-decorate(inject(TYPES.RService), CsvJobData, 0)
+decorateInjectable(CsvJobData, depsTypes)
 
 module.exports = CsvJobData

--- a/workers/loc.api/has.grc.service/index.js
+++ b/workers/loc.api/has.grc.service/index.js
@@ -1,14 +1,12 @@
 'use strict'
 
 const { promisify } = require('util')
-const {
-  decorate,
-  injectable,
-  inject
-} = require('inversify')
 
-const TYPES = require('../di/types')
+const { decorateInjectable } = require('../di/utils')
 
+const depsTypes = (TYPES) => [
+  TYPES.Link
+]
 class HasGrcService {
   constructor (link) {
     this.link = link
@@ -49,7 +47,6 @@ class HasGrcService {
   }
 }
 
-decorate(injectable(), HasGrcService)
-decorate(inject(TYPES.Link), HasGrcService, 0)
+decorateInjectable(HasGrcService, depsTypes)
 
 module.exports = HasGrcService

--- a/workers/loc.api/interrupter/index.js
+++ b/workers/loc.api/interrupter/index.js
@@ -1,10 +1,8 @@
 'use strict'
 
 const EventEmitter = require('events')
-const {
-  decorate,
-  injectable
-} = require('inversify')
+
+const { decorateInjectable } = require('../di/utils')
 
 class Interrupter extends EventEmitter {
   constructor () {
@@ -76,6 +74,6 @@ class Interrupter extends EventEmitter {
   }
 }
 
-decorate(injectable(), Interrupter)
+decorateInjectable(Interrupter)
 
 module.exports = Interrupter


### PR DESCRIPTION
This PR adds a helper to decorate injectable class of modules to improve readability and reduce the writing code of new modules

instead of:
```js
const {
  decorate,
  injectable,
  inject
} = require('inversify')

const TYPES = require('../../di/types')

class SyncCollsManager {
  constructor (
    dao,
    TABLES_NAMES,
    syncSchema
  ) {
    this.dao = dao
    this.TABLES_NAMES = TABLES_NAMES
    this.syncSchema = syncSchema
  }
}

decorate(injectable(), SyncCollsManager)
decorate(inject(TYPES.DAO), SyncCollsManager, 0)
decorate(inject(TYPES.TABLES_NAMES), SyncCollsManager, 1)
decorate(inject(TYPES.SyncSchema), SyncCollsManager, 2)

module.exports = SyncCollsManager
```

writes as shown bellow:
```js
const { decorateInjectable } = require('../../di/utils')

const depsTypes = (TYPES) => [
  TYPES.DAO,
  TYPES.TABLES_NAMES,
  TYPES.SyncSchema
]
class SyncCollsManager {
  constructor (
    dao,
    TABLES_NAMES,
    syncSchema
  ) {
    this.dao = dao
    this.TABLES_NAMES = TABLES_NAMES
    this.syncSchema = syncSchema
  }
}

decorateInjectable(SyncCollsManager, depsTypes)

module.exports = SyncCollsManager
```