### PR TITLE
Add ability to return local csv folder path in response

### DIFF
--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -108,7 +108,8 @@ module.exports = ({
           TYPES.ProcessorQueue,
           TYPES.HasGrcService,
           TYPES.CsvJobData,
-          TYPES.RService
+          TYPES.RService,
+          TYPES.RootPath
         ]
       ))
     bind(TYPES.WriteDataToStream).toConstantValue(

--- a/workers/loc.api/generate-csv/index.js
+++ b/workers/loc.api/generate-csv/index.js
@@ -9,10 +9,14 @@ const {
 const {
   EmailSendingError
 } = require('../errors')
+const getLocalCsvFolderPaths = require(
+  '../queue/helpers/get-local-csv-folder-paths'
+)
 
 const _getCsvStoreStatus = async (
   hasGrcService,
-  args
+  args,
+  rootPath
 ) => {
   const { email } = { ...args.params }
 
@@ -20,7 +24,14 @@ const _getCsvStoreStatus = async (
     !email ||
     typeof email !== 'string'
   ) {
-    return { isSaveLocaly: true }
+    const {
+      localCsvFolderPath
+    } = getLocalCsvFolderPaths(rootPath)
+
+    return {
+      isSaveLocaly: true,
+      localCsvFolderPath
+    }
   }
 
   if (!await hasGrcService.hasS3AndSendgrid()) {
@@ -75,7 +86,8 @@ module.exports = (
   processorQueue,
   hasGrcService,
   csvJobData,
-  rService
+  rService,
+  rootPath
 ) => async (
   name,
   args
@@ -84,7 +96,8 @@ module.exports = (
 
   const status = await _getCsvStoreStatus(
     hasGrcService,
-    args
+    args,
+    rootPath
   )
   const checkingDataArr = _getFilterModelNamesAndArgs(
     name,

--- a/workers/loc.api/queue/helpers/get-local-csv-folder-paths.js
+++ b/workers/loc.api/queue/helpers/get-local-csv-folder-paths.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const path = require('path')
+const argv = require('yargs').argv
+
+module.exports = (rootPath) => {
+  const localCsvFolderPath = path.isAbsolute(argv.csvFolder)
+    ? argv.csvFolder
+    : path.join(rootPath, argv.csvFolder)
+  const tempCsvFolderPath = path.isAbsolute(argv.tempFolder)
+    ? argv.tempFolder
+    : path.join(rootPath, argv.tempFolder)
+
+  return {
+    localCsvFolderPath,
+    tempCsvFolderPath
+  }
+}

--- a/workers/loc.api/queue/helpers/index.js
+++ b/workers/loc.api/queue/helpers/index.js
@@ -6,10 +6,14 @@ const {
   writableToPromise,
   createUniqueFileName
 } = require('./utils')
+const getLocalCsvFolderPaths = require(
+  './get-local-csv-folder-paths'
+)
 
 module.exports = {
   moveFileToLocalStorage,
   writableToPromise,
   createUniqueFileName,
-  getCompleteFileName
+  getCompleteFileName,
+  getLocalCsvFolderPaths
 }

--- a/workers/loc.api/queue/helpers/utils.js
+++ b/workers/loc.api/queue/helpers/utils.js
@@ -14,6 +14,9 @@ const chmod = promisify(fs.chmod)
 const isElectronjsEnv = argv.isElectronjsEnv
 
 const getCompleteFileName = require('./get-complete-file-name')
+const getLocalCsvFolderPaths = require(
+  './get-local-csv-folder-paths'
+)
 
 const _checkAndCreateDir = async (dirPath) => {
   try {
@@ -82,15 +85,13 @@ const moveFileToLocalStorage = async (
   isAddedUniqueEndingToCsvName,
   chunkCommonFolder
 ) => {
-  const localStorageDirPath = path.isAbsolute(argv.csvFolder)
-    ? argv.csvFolder
-    : path.join(rootPath, argv.csvFolder)
+  const { localCsvFolderPath } = getLocalCsvFolderPaths(rootPath)
   const fullCsvDirPath = (
     chunkCommonFolder &&
     typeof chunkCommonFolder === 'string'
   )
-    ? path.join(localStorageDirPath, chunkCommonFolder)
-    : localStorageDirPath
+    ? path.join(localCsvFolderPath, chunkCommonFolder)
+    : localCsvFolderPath
 
   await _checkAndCreateDir(fullCsvDirPath)
 
@@ -142,21 +143,19 @@ const createUniqueFileName = async (rootPath, count = 0) => {
     throw new Error('ERR_CREATE_UNIQUE_FILE_NAME')
   }
 
-  const tempDirPath = path.isAbsolute(argv.tempFolder)
-    ? argv.tempFolder
-    : path.join(rootPath, argv.tempFolder)
+  const { tempCsvFolderPath } = getLocalCsvFolderPaths(rootPath)
 
-  await _checkAndCreateDir(tempDirPath)
+  await _checkAndCreateDir(tempCsvFolderPath)
 
   const uniqueFileName = `${uuidv4()}.csv`
 
-  const files = await readdir(tempDirPath)
+  const files = await readdir(tempCsvFolderPath)
 
   if (files.some(file => file === uniqueFileName)) {
     return createUniqueFileName(rootPath, count)
   }
 
-  return path.join(tempDirPath, uniqueFileName)
+  return path.join(tempCsvFolderPath, uniqueFileName)
 }
 
 const writableToPromise = stream => {


### PR DESCRIPTION
This PR adds an ability to return the local csv folder path in response when exporting csv locally for the electron app to keep aware users

Request example:
```js
{
  "auth": { "token": "123token321" },
  "method": "getMultipleCsv",
  "params": {
    "language": "en",
    "multiExport": [
      {
        "start": 1509528489230,
        "end": 1613208489230,
        "limit": 500,
        "timezone": "Etc/UTC",
        "dateFormat": "DD-MM-YY",
        "milliseconds": false,
        "method": "getLedgersCsv"
      }
    ]
  }
}
```

Response example:
```js
{
  "result": {
    "isSaveLocaly": true,
    "localCsvFolderPath": "/home/someuser/Documents/bitfinex/reports"
  },
  "id": null
}
```