### PR TITLE
Add a new option for  CSVs that have 4 digit years

### DIFF
--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -45,7 +45,14 @@ const timezone = {
 }
 const dateFormat = {
   type: 'string',
-  enum: ['DD-MM-YY', 'MM-DD-YY', 'YY-MM-DD']
+  enum: [
+    'DD-MM-YY',
+    'DD-MM-YYYY',
+    'MM-DD-YY',
+    'MM-DD-YYYY',
+    'YY-MM-DD',
+    'YYYY-MM-DD'
+  ]
 }
 const language = {
   type: 'string',


### PR DESCRIPTION
This PR adds a new option for  CSVs that have 4 digit years

Request example:

```json
{
    "auth": {
        "apiKey": "apiKey",
        "apiSecret": "apiSecret"
    },
    "method": "getLedgersCsv",
    "params": {
        "dateFormat": "YYYY-MM-DD"
    }
}
```