### PR TITLE
Fix putting csv files into common folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "grenache-grape": "^0.9.8",
     "mocha": "^6.1.4",
     "nodemon": "^1.18.6",
-    "standard": "^14.3.1",
+    "standard": "^16.0.3",
     "supertest": "^4.0.2"
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "reflect-metadata": "^0.1.13",
     "uuid": "^3.3.2",
     "winston": "^3.1.0",
-    "yargs": "^13.2.4"
+    "yargs": "^16.2.0"
   },
   "devDependencies": {
     "bfx-report-express": "git+https://github.com/bitfinexcom/bfx-report-express.git",

--- a/test/helpers/helpers.boot.js
+++ b/test/helpers/helpers.boot.js
@@ -43,9 +43,9 @@ const startEnvironment = async (
 
   return isNotStartedEnv
     ? {
-      wrkIpcs,
-      wrksReportServiceApi
-    }
+        wrkIpcs,
+        wrksReportServiceApi
+      }
     : new Promise((resolve, reject) => {
       const [grape1] = grapes
 

--- a/test/helpers/helpers.core.js
+++ b/test/helpers/helpers.core.js
@@ -15,10 +15,12 @@ const rmDB = async (
 ) => {
   try {
     const files = await readdir(dir)
-    const promisesArr = files.map(file => {
+    const promisesArr = files.map((file) => {
       if (exclude.every(exFile => exFile !== file)) {
         return unlink(path.join(dir, file))
       }
+
+      return null
     })
 
     const res = await Promise.all(promisesArr)

--- a/test/helpers/helpers.tests.js
+++ b/test/helpers/helpers.tests.js
@@ -41,7 +41,12 @@ const testProcQueue = (procRes, opts) => {
   assert.isBoolean(procRes.isUnauth)
 }
 
-const testMethodOfGettingCsv = async (procPromise, aggrPromise, res) => {
+const testMethodOfGettingCsv = async (
+  procPromise,
+  aggrPromise,
+  res,
+  extraTestCase = () => {}
+) => {
   assert.isObject(res.body)
   assert.propertyVal(res.body, 'id', 5)
   assert.isObject(res.body.result)
@@ -69,6 +74,12 @@ const testMethodOfGettingCsv = async (procPromise, aggrPromise, res) => {
       assert.isOk(fs.existsSync(newFilePath))
     })
   }
+
+  extraTestCase({
+    procRes,
+    aggrRes,
+    result: res.body.result
+  })
 }
 
 module.exports = {

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -373,20 +373,20 @@ class CsvJobData {
     const csvArgs = getCsvArgs(args, 'publicTrades', { isTradingPair })
     const columnsCsv = (isTradingPair)
       ? {
-        id: '#',
-        mts: 'TIME',
-        price: 'PRICE',
-        amount: 'AMOUNT',
-        symbol: 'PAIR'
-      }
+          id: '#',
+          mts: 'TIME',
+          price: 'PRICE',
+          amount: 'AMOUNT',
+          symbol: 'PAIR'
+        }
       : {
-        id: '#',
-        mts: 'TIME',
-        rate: 'RATE',
-        amount: 'AMOUNT',
-        period: 'PERIOD',
-        symbol: 'CURRENCY'
-      }
+          id: '#',
+          mts: 'TIME',
+          rate: 'RATE',
+          amount: 'AMOUNT',
+          period: 'PERIOD',
+          symbol: 'CURRENCY'
+        }
 
     const jobData = {
       userInfo,

--- a/workers/loc.api/helpers/get-timezone-conf.js
+++ b/workers/loc.api/helpers/get-timezone-conf.js
@@ -8,13 +8,13 @@ const _getTimezoneName = (name) => {
     ['Kiev', ['Kyiv']]
   ]
 
-  aliases.some(item => {
+  for (const item of aliases) {
     if (item[1].some(alias => alias === name)) {
       _name = item[0]
 
-      return true
+      break
     }
-  })
+  }
 
   const arr = _name.split(/[_-\s,./\\|]/g)
   const regExp = new RegExp(`${arr.join('.*')}`, 'gi')
@@ -43,11 +43,11 @@ module.exports = (name) => {
   const timezoneOffset = _getTimezoneOffset(timezoneName)
   return timezoneName
     ? {
-      timezoneName,
-      timezoneOffset
-    }
+        timezoneName,
+        timezoneOffset
+      }
     : {
-      timezoneName: 'UTC',
-      timezoneOffset: 0
-    }
+        timezoneName: 'UTC',
+        timezoneOffset: 0
+      }
 }

--- a/workers/loc.api/helpers/prepare-response.js
+++ b/workers/loc.api/helpers/prepare-response.js
@@ -405,10 +405,10 @@ const prepareResponse = (
     symbols.length > 0
   )
     ? filterResponse(
-      apiRes,
-      { $in: { [symbPropName]: symbols } },
-      true
-    )
+        apiRes,
+        { $in: { [symbPropName]: symbols } },
+        true
+      )
     : apiRes
   const res = filterResponse(
     filteredResBySymb,

--- a/workers/loc.api/helpers/utils.js
+++ b/workers/loc.api/helpers/utils.js
@@ -54,8 +54,8 @@ const parsePositionsAuditId = (args) => {
   const { id } = { ...params }
   const parsedId = Array.isArray(id)
     ? id.map(_id => (
-      typeof _id === 'string' ? Number.parseInt(_id) : _id)
-    )
+        typeof _id === 'string' ? Number.parseInt(_id) : _id)
+      )
     : id
 
   return {

--- a/workers/loc.api/queue/aggregator.js
+++ b/workers/loc.api/queue/aggregator.js
@@ -20,7 +20,7 @@ module.exports = (
   return async (job) => {
     try {
       const {
-        chunkCommonFolder,
+        chunkCommonFolders,
         userInfo,
         name,
         filePaths,
@@ -85,7 +85,7 @@ module.exports = (
           { ...subParamsArr[count] },
           userInfo.username,
           isAddedUniqueEndingToCsvName,
-          chunkCommonFolder
+          chunkCommonFolders[count]
         )
 
         newFilePaths.push(newFilePath)

--- a/workers/loc.api/queue/processor.js
+++ b/workers/loc.api/queue/processor.js
@@ -49,6 +49,7 @@ module.exports = (
 
   return async (job) => {
     const filePaths = []
+    const chunkCommonFolders = []
     const subParamsArr = []
     const isUnauth = job.data.isUnauth || false
     const jobsData = Array.isArray(job.data.jobsData)
@@ -59,7 +60,6 @@ module.exports = (
       job.data.args.params = { ...job.data.args.params }
 
       const {
-        chunkCommonFolder,
         userInfo,
         userId,
         name,
@@ -81,6 +81,7 @@ module.exports = (
         filePaths.push(filePath)
 
         const {
+          chunkCommonFolder,
           args: { params },
           name,
           fileNamesMap,
@@ -92,6 +93,7 @@ module.exports = (
           name,
           fileNamesMap
         })
+        chunkCommonFolders.push(chunkCommonFolder)
 
         const write = isUnauth
           ? 'Your file could not be completed, please try again'
@@ -126,7 +128,7 @@ module.exports = (
 
       job.done()
       processorQueue.emit('completed', {
-        chunkCommonFolder,
+        chunkCommonFolders,
         userInfo,
         userId,
         name,

--- a/workers/loc.api/queue/upload-to-s3/index.js
+++ b/workers/loc.api/queue/upload-to-s3/index.js
@@ -124,10 +124,10 @@ module.exports = (
 
       const signature = isSignReq
         ? await grcBfxReq({
-          service: 'rest:ext:gpg',
-          action: 'getDigitalSignature',
-          args: [hexStrBuff, userInfo]
-        })
+            service: 'rest:ext:gpg',
+            action: 'getDigitalSignature',
+            args: [hexStrBuff, userInfo]
+          })
         : null
       const reportS3 = await grcBfxReq({
         service: 'rest:ext:s3',

--- a/workers/loc.api/queue/write-data-to-stream/helpers.js
+++ b/workers/loc.api/queue/write-data-to-stream/helpers.js
@@ -60,8 +60,11 @@ const _formatters = {
       return symbol.slice(1)
     }
 
-    return `${symbol.slice(1, 4)}${symbol[4]
-      ? '/' : ''}${symbol.slice(4, 7)}`
+    const firstPart = symbol.slice(1, 4)
+    const secondPart = symbol.slice(4, 7)
+    const separator = symbol[4] ? '/' : ''
+
+    return `${firstPart}${separator}${secondPart}`
   },
   side: side => {
     let msg


### PR DESCRIPTION
This PR fixes putting `csv` files into a common folder. The issue is that it doesn't work with multi-export. This feature was done with these PRs:
  - https://github.com/bitfinexcom/bfx-report/pull/204
  - https://github.com/bitfinexcom/bfx-reports-framework/pull/145

Adds ability to execute extra test cases for csv endpoints

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-report/pull/229