### PR TITLE
Rework JSON-RPC response

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -66,6 +66,7 @@ describe('API', () => {
 
     assert.isObject(res.body)
     assert.propertyVal(res.body, 'id', 5)
+    assert.isString(res.body.jsonrpc)
     assert.isNotOk(res.body.result)
   })
 
@@ -171,7 +172,6 @@ describe('API', () => {
     assert.isBoolean(res.body.result.isSubAccount)
     assert.strictEqual(res.body.result.email, 'fake@email.fake')
     assert.propertyVal(res.body, 'id', 5)
-    assert.propertyVal(res.body, 'id', 5)
   })
 
   it('it should not be successfully auth', async function () {
@@ -194,7 +194,9 @@ describe('API', () => {
     assert.isObject(res.body.error)
     assert.propertyVal(res.body.error, 'code', 401)
     assert.propertyVal(res.body.error, 'message', 'Unauthorized')
+    assert.propertyVal(res.body.error, 'data', null)
     assert.propertyVal(res.body, 'id', null)
+    assert.isString(res.body.jsonrpc)
   })
 
   it('it should be successfully performed by the getUsersTimeConf method', async function () {
@@ -1126,12 +1128,19 @@ describe('API', () => {
         id: 5
       })
       .expect('Content-Type', /json/)
-      .expect(500)
+      .expect(400)
 
     assert.isObject(res.body)
     assert.isObject(res.body.error)
-    assert.propertyVal(res.body.error, 'code', 500)
-    assert.propertyVal(res.body.error, 'message', 'Internal Server Error')
+    assert.propertyVal(res.body.error, 'code', 400)
+    assert.isArray(res.body.error.data)
+    assert.isAbove(res.body.error.data.length, 0)
+
+    res.body.error.data.forEach((item) => {
+      assert.isObject(item)
+    })
+
+    assert.propertyVal(res.body.error, 'message', 'Args params is not valid')
     assert.propertyVal(res.body, 'id', 5)
   })
 
@@ -1199,12 +1208,12 @@ describe('API', () => {
         id: 5
       })
       .expect('Content-Type', /json/)
-      .expect(500)
+      .expect(400)
 
     assert.isObject(res.body)
     assert.isObject(res.body.error)
-    assert.propertyVal(res.body.error, 'code', 500)
-    assert.propertyVal(res.body.error, 'message', 'Internal Server Error')
+    assert.propertyVal(res.body.error, 'code', 400)
+    assert.propertyVal(res.body.error, 'message', 'Args params is not valid')
     assert.propertyVal(res.body, 'id', 5)
   })
 
@@ -1444,12 +1453,12 @@ describe('API', () => {
         id: 5
       })
       .expect('Content-Type', /json/)
-      .expect(500)
+      .expect(400)
 
     assert.isObject(res.body)
     assert.isObject(res.body.error)
-    assert.propertyVal(res.body.error, 'code', 500)
-    assert.propertyVal(res.body.error, 'message', 'Internal Server Error')
+    assert.propertyVal(res.body.error, 'code', 400)
+    assert.propertyVal(res.body.error, 'message', 'Args params is not valid')
     assert.propertyVal(res.body, 'id', 5)
   })
 
@@ -1607,11 +1616,11 @@ describe('API', () => {
         id: 5
       })
       .expect('Content-Type', /json/)
-      .expect(400)
+      .expect(422)
 
     assert.isObject(res.body)
     assert.isObject(res.body.error)
-    assert.propertyVal(res.body.error, 'code', 400)
+    assert.propertyVal(res.body.error, 'code', 422)
     assert.propertyVal(res.body.error, 'message', 'A greater limit is needed as to show the data correctly')
     assert.propertyVal(res.body, 'id', 5)
   })

--- a/test/2-api-filter.spec.js
+++ b/test/2-api-filter.spec.js
@@ -635,12 +635,12 @@ describe('API filter', () => {
         .type('json')
         .send(args)
         .expect('Content-Type', /json/)
-        .expect(500)
+        .expect(400)
 
       assert.isObject(res.body)
       assert.isObject(res.body.error)
-      assert.propertyVal(res.body.error, 'code', 500)
-      assert.propertyVal(res.body.error, 'message', 'Internal Server Error')
+      assert.propertyVal(res.body.error, 'code', 400)
+      assert.propertyVal(res.body.error, 'message', 'Args params is not valid')
       assert.propertyVal(res.body, 'id', 5)
     }
   })

--- a/test/3-report-signature.spec.js
+++ b/test/3-report-signature.spec.js
@@ -168,7 +168,8 @@ describe('Signature', () => {
     assert.isOk(res)
   })
 
-  it('it should be successfully performed by the /verify-digital-signature route', async function () {
+  // TODO: The feature is pending
+  it.skip('it should be successfully performed by the /verify-digital-signature route', async function () {
     this.timeout(5000)
 
     const res = await agent

--- a/test/4-queue-base.spec.js
+++ b/test/4-queue-base.spec.js
@@ -135,12 +135,12 @@ describe('Queue', () => {
         id: 5
       })
       .expect('Content-Type', /json/)
-      .expect(500)
+      .expect(400)
 
     assert.isObject(res.body)
     assert.isObject(res.body.error)
-    assert.propertyVal(res.body.error, 'code', 500)
-    assert.propertyVal(res.body.error, 'message', 'Internal Server Error')
+    assert.propertyVal(res.body.error, 'code', 400)
+    assert.propertyVal(res.body.error, 'message', 'Args params is not valid')
     assert.propertyVal(res.body, 'id', 5)
   })
 
@@ -540,11 +540,11 @@ describe('Queue', () => {
         id: 5
       })
       .expect('Content-Type', /json/)
-      .expect(400)
+      .expect(422)
 
     assert.isObject(res.body)
     assert.isObject(res.body.error)
-    assert.propertyVal(res.body.error, 'code', 400)
+    assert.propertyVal(res.body.error, 'code', 422)
     assert.propertyVal(res.body.error, 'message', 'For public trades export please select a time frame smaller than a month')
     assert.propertyVal(res.body, 'id', 5)
   })
@@ -569,12 +569,12 @@ describe('Queue', () => {
         id: 5
       })
       .expect('Content-Type', /json/)
-      .expect(500)
+      .expect(400)
 
     assert.isObject(res.body)
     assert.isObject(res.body.error)
-    assert.propertyVal(res.body.error, 'code', 500)
-    assert.propertyVal(res.body.error, 'message', 'Internal Server Error')
+    assert.propertyVal(res.body.error, 'code', 400)
+    assert.propertyVal(res.body.error, 'message', 'Args params is not valid')
     assert.propertyVal(res.body, 'id', 5)
   })
 

--- a/workers/loc.api/errors/helpers.js
+++ b/workers/loc.api/errors/helpers.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const getErrorArgs = (
+  args,
+  messageByDefault = 'ERR_ERROR_HAS_OCCURRED'
+) => {
+  const argsObj = typeof args === 'string'
+    ? { message: args }
+    : { ...args }
+  const {
+    message = messageByDefault,
+    data = null
+  } = argsObj
+
+  return { message, data }
+}
+
+module.exports = {
+  getErrorArgs
+}

--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -1,15 +1,59 @@
 'use strict'
 
 class BaseError extends Error {
-  constructor (message) {
+  constructor (param) {
+    const obj = typeof param === 'string'
+      ? { message: param }
+      : { ...param }
+    const {
+      message = 'ERR_ERROR_HAS_OCCURRED',
+      data = null
+    } = obj
     super(message)
 
     this.name = this.constructor.name
     this.message = message
     this.statusCode = 500
     this.statusMessage = 'Internal Server Error'
+    this.data = data
 
     Error.captureStackTrace(this, this.constructor)
+  }
+}
+
+class BadRequestError extends BaseError {
+  constructor (message = 'ERR_BED_REQUEST') {
+    super(message)
+
+    this.statusCode = 400
+    this.statusMessage = 'Bed request'
+  }
+}
+
+class AuthError extends BaseError {
+  constructor (message = 'ERR_AUTH_UNAUTHORIZED') {
+    super(message)
+
+    this.statusCode = 401
+    this.statusMessage = 'Unauthorized'
+  }
+}
+
+class ConflictError extends BaseError {
+  constructor (message = 'ERR_CONFLICT') {
+    super(message)
+
+    this.statusCode = 409
+    this.statusMessage = 'Conflict'
+  }
+}
+
+class UnprocessableEntityError extends BaseError {
+  constructor (message = 'ERR_UNPROCESSABLE_ENTITY') {
+    super(message)
+
+    this.statusCode = 422
+    this.statusMessage = 'Unprocessable Entity'
   }
 }
 
@@ -25,25 +69,18 @@ class FindMethodToGetCsvFileError extends FindMethodError {
   }
 }
 
-class AuthError extends BaseError {
-  constructor (message = 'ERR_AUTH_UNAUTHORIZED') {
+class ArgsParamsError extends BadRequestError {
+  constructor (data, message = 'ERR_ARGS_NO_PARAMS') {
     super(message)
-  }
-}
 
-class ArgsParamsError extends BaseError {
-  constructor (obj, message = 'ERR_ARGS_NO_PARAMS') {
-    const str = obj && typeof obj === 'object'
-      ? ` ${JSON.stringify(obj)}`
-      : ''
-
-    super(`${message}${str}`)
+    this.statusMessage = 'Args params is not valid'
+    this.data = data
   }
 }
 
 class ArgsParamsFilterError extends ArgsParamsError {
-  constructor (obj) {
-    super(obj, 'ERR_ARGS_PARAMS_FILTER_IS_NOT_VALID')
+  constructor (data) {
+    super(data, 'ERR_ARGS_PARAMS_FILTER_IS_NOT_VALID')
   }
 }
 
@@ -59,27 +96,35 @@ class EmailSendingError extends BaseError {
   }
 }
 
-class MinLimitParamError extends BaseError {
+class MinLimitParamError extends UnprocessableEntityError {
   constructor (message = 'ERR_GREATER_LIMIT_IS_NEEDED') {
     super(message)
+
+    this.statusMessage = 'A greater limit is needed as to show the data correctly'
   }
 }
 
-class QueueJobAddingError extends BaseError {
+class QueueJobAddingError extends ConflictError {
   constructor (message = 'ERR_HAS_JOB_IN_QUEUE') {
     super(message)
+
+    this.statusMessage = 'Spam restriction mode, user already has an export on queue'
   }
 }
 
-class SymbolsTypeError extends BaseError {
+class SymbolsTypeError extends UnprocessableEntityError {
   constructor (message = 'ERR_SYMBOLS_ARE_NOT_OF_SAME_TYPE') {
     super(message)
+
+    this.statusMessage = 'Symbols are not of same type'
   }
 }
 
-class TimeframeError extends BaseError {
+class TimeframeError extends UnprocessableEntityError {
   constructor (message = 'ERR_TIME_FRAME_MORE_THAN_MONTH') {
     super(message)
+
+    this.statusMessage = 'For public trades export please select a time frame smaller than a month'
   }
 }
 
@@ -98,10 +143,12 @@ class FilterParamsValidSchemaFindingError extends ParamsValidSchemaFindingError 
 class LedgerPaymentFilteringParamsError extends ArgsParamsError {
   constructor (message = 'ERR_FILTER_BY_MARGIN_AND_AFFILIATE_PARAMS_MAY_NOT_APPLY_TOGETHER') {
     super(message)
+
+    this.statusMessage = 'Filter by margin and affiliate params may not apply together'
   }
 }
 
-class GrcSlackAvailabilityError extends ArgsParamsError {
+class GrcSlackAvailabilityError extends BaseError {
   constructor (message = 'ERR_GRC_SLACK_IS_NOT_AVAILABLE') {
     super(message)
   }
@@ -109,9 +156,13 @@ class GrcSlackAvailabilityError extends ArgsParamsError {
 
 module.exports = {
   BaseError,
+  BadRequestError,
+  AuthError,
+  ConflictError,
+  UnprocessableEntityError,
+
   FindMethodError,
   FindMethodToGetCsvFileError,
-  AuthError,
   ArgsParamsError,
   GrenacheServiceConfigArgsError,
   EmailSendingError,

--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -60,9 +60,11 @@ class FindMethodError extends BaseError {
   }
 }
 
-class FindMethodToGetCsvFileError extends FindMethodError {
+class FindMethodToGetCsvFileError extends BadRequestError {
   constructor (message = 'ERR_METHOD_TO_GET_CSV_FILE_NOT_FOUND') {
     super(message)
+
+    this.statusMessage = 'Method to get csv file not found'
   }
 }
 

--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -6,6 +6,8 @@ class BaseError extends Error {
 
     this.name = this.constructor.name
     this.message = message
+    this.statusCode = 500
+    this.statusMessage = 'Internal Server Error'
 
     Error.captureStackTrace(this, this.constructor)
   }

--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -1,14 +1,11 @@
 'use strict'
 
+const { getErrorArgs } = require('./helpers')
+
 class BaseError extends Error {
-  constructor (param) {
-    const obj = typeof param === 'string'
-      ? { message: param }
-      : { ...param }
-    const {
-      message = 'ERR_ERROR_HAS_OCCURRED',
-      data = null
-    } = obj
+  constructor (args) {
+    const { message, data } = getErrorArgs(args)
+
     super(message)
 
     this.name = this.constructor.name
@@ -70,17 +67,20 @@ class FindMethodToGetCsvFileError extends FindMethodError {
 }
 
 class ArgsParamsError extends BadRequestError {
-  constructor (data, message = 'ERR_ARGS_NO_PARAMS') {
-    super(message)
+  constructor (args) {
+    const _args = getErrorArgs(args, 'ERR_ARGS_NO_PARAMS')
+
+    super(_args)
 
     this.statusMessage = 'Args params is not valid'
-    this.data = data
   }
 }
 
 class ArgsParamsFilterError extends ArgsParamsError {
-  constructor (data) {
-    super(data, 'ERR_ARGS_PARAMS_FILTER_IS_NOT_VALID')
+  constructor (args) {
+    const _args = getErrorArgs(args, 'ERR_ARGS_PARAMS_FILTER_IS_NOT_VALID')
+
+    super(_args)
   }
 }
 

--- a/workers/loc.api/helpers/check-filter-params.js
+++ b/workers/loc.api/helpers/check-filter-params.js
@@ -140,5 +140,5 @@ module.exports = (
     return
   }
 
-  throw new ArgsParamsFilterError(ajv.errors)
+  throw new ArgsParamsFilterError({ data: ajv.errors })
 }

--- a/workers/loc.api/helpers/check-params.js
+++ b/workers/loc.api/helpers/check-params.js
@@ -47,7 +47,7 @@ module.exports = (
     (checkParamsField || args.params) &&
     !ajv.validate(_schema, args.params)
   ) {
-    throw new ArgsParamsError(ajv.errors)
+    throw new ArgsParamsError({ data: ajv.errors })
   }
   if (
     args.params &&

--- a/workers/loc.api/helpers/check-params.js
+++ b/workers/loc.api/helpers/check-params.js
@@ -5,6 +5,7 @@ const Ajv = require('ajv')
 
 const schema = require('./schema')
 const {
+  UnprocessableEntityError,
   ArgsParamsError,
   ParamsValidSchemaFindingError
 } = require('../errors')
@@ -56,12 +57,14 @@ module.exports = (
     args.params.start >= args.params.end
   ) {
     // Use same error format like Ajv for consistency
-    throw new ArgsParamsError([{
-      instancePath: '/end',
-      schemaPath: '#/properties/end/type',
-      keyword: 'type',
-      params: { type: 'integer' },
-      message: 'must be start < end'
-    }])
+    throw new UnprocessableEntityError({
+      data: [{
+        instancePath: '/end',
+        schemaPath: '#/properties/end/type',
+        keyword: 'type',
+        params: { type: 'integer' },
+        message: 'must be start < end'
+      }]
+    })
   }
 }

--- a/workers/loc.api/responder/index.js
+++ b/workers/loc.api/responder/index.js
@@ -44,7 +44,9 @@ const _getErrorWithMetadataForNonBaseError = (err) => {
     !err ||
     typeof err !== 'object'
   ) {
-    return new BaseError()
+    return typeof err === 'string'
+      ? new BaseError(err)
+      : new BaseError()
   }
   if (err instanceof BaseError) {
     return err

--- a/workers/loc.api/responder/index.js
+++ b/workers/loc.api/responder/index.js
@@ -169,22 +169,22 @@ module.exports = (
       }
 
       resFn
-        .then((res) => cb(null, _makeJsonRpcResponse(res)))
+        .then((res) => cb(null, _makeJsonRpcResponse(args, res)))
         .catch((err) => {
           _logError(logger, err, name)
 
-          cb(_makeJsonRpcResponse(err))
+          cb(null, _makeJsonRpcResponse(args, err))
         })
 
       return
     }
 
     if (!cb) return resFn
-    cb(null, _makeJsonRpcResponse(resFn))
+    cb(null, _makeJsonRpcResponse(args, resFn))
   } catch (err) {
     _logError(logger, err, name)
 
     if (!cb) throw err
-    cb(_makeJsonRpcResponse(err))
+    cb(null, _makeJsonRpcResponse(args, err))
   }
 }

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -87,7 +87,7 @@ class ReportService extends Api {
           symbPropName: 'symbol'
         }
       )
-    }, 'getPositionsSnapshot', cb)
+    }, 'getPositionsSnapshot', args, cb)
   }
 
   getFilterModels (space, args, cb) {
@@ -101,7 +101,7 @@ class ReportService extends Api {
         }, {})
 
       return models
-    }, 'getFilterModels', cb)
+    }, 'getFilterModels', args, cb)
   }
 
   verifyDigitalSignature (space, args, cb) {
@@ -111,13 +111,13 @@ class ReportService extends Api {
         action: 'verifyDigitalSignature',
         args: [null, args]
       })
-    }, 'verifyDigitalSignature', cb)
+    }, 'verifyDigitalSignature', args, cb)
   }
 
   isSyncModeConfig (space, args, cb) {
     return this._responder(() => {
       return this.container.get(TYPES.CONF).syncMode
-    }, 'isSyncModeConfig', cb)
+    }, 'isSyncModeConfig', args, cb)
   }
 
   verifyUser (space, args, cb) {
@@ -140,7 +140,7 @@ class ReportService extends Api {
         id,
         isSubAccount: false
       }
-    }, 'verifyUser', cb)
+    }, 'verifyUser', args, cb)
   }
 
   generateToken (space, args, cb) {
@@ -154,7 +154,7 @@ class ReportService extends Api {
         writePermission: false,
         _cust_ip: '0'
       })
-    }, 'verifyUser', cb)
+    }, 'verifyUser', args, cb)
   }
 
   getUsersTimeConf (space, args, cb) {
@@ -162,7 +162,7 @@ class ReportService extends Api {
       const { timezone } = await this._getUserInfo(args)
 
       return getTimezoneConf(timezone)
-    }, 'getUsersTimeConf', cb)
+    }, 'getUsersTimeConf', args, cb)
   }
 
   getSymbols (space, args, cb) {
@@ -199,7 +199,7 @@ class ReportService extends Api {
       accountCache.set('symbols', res)
 
       return res
-    }, 'getSymbols', cb)
+    }, 'getSymbols', args, cb)
   }
 
   getSettings (space, args, cb) {
@@ -210,7 +210,7 @@ class ReportService extends Api {
       const rest = this._getREST(auth)
 
       return rest.getSettings(keys)
-    }, 'getSettings', cb)
+    }, 'getSettings', args, cb)
   }
 
   updateSettings (space, args, cb) {
@@ -221,7 +221,7 @@ class ReportService extends Api {
       const rest = this._getREST(auth)
 
       return rest.updateSettings(settings)
-    }, 'updateSettings', cb)
+    }, 'updateSettings', args, cb)
   }
 
   getTickersHistory (space, args, cb) {
@@ -247,7 +247,7 @@ class ReportService extends Api {
           requireFields: ['symbol']
         }
       )
-    }, 'getTickersHistory', cb)
+    }, 'getTickersHistory', args, cb)
   }
 
   getPositionsHistory (space, args, cb) {
@@ -260,7 +260,7 @@ class ReportService extends Api {
           symbPropName: 'symbol'
         }
       )
-    }, 'getPositionsHistory', cb)
+    }, 'getPositionsHistory', args, cb)
   }
 
   getActivePositions (space, args, cb) {
@@ -271,7 +271,7 @@ class ReportService extends Api {
       return Array.isArray(positions)
         ? positions.filter(({ status }) => status === 'ACTIVE')
         : []
-    }, 'getActivePositions', cb)
+    }, 'getActivePositions', args, cb)
   }
 
   getPositionsAudit (space, args, cb) {
@@ -286,7 +286,7 @@ class ReportService extends Api {
           symbPropName: 'symbol'
         }
       )
-    }, 'getPositionsAudit', cb)
+    }, 'getPositionsAudit', args, cb)
   }
 
   getWallets (space, args, cb) {
@@ -296,7 +296,7 @@ class ReportService extends Api {
       const rest = this._getREST(args.auth)
 
       return rest.wallets()
-    }, 'getWallets', cb)
+    }, 'getWallets', args, cb)
   }
 
   getLedgers (space, args, cb) {
@@ -309,7 +309,7 @@ class ReportService extends Api {
           symbPropName: 'currency'
         }
       )
-    }, 'getLedgers', cb)
+    }, 'getLedgers', args, cb)
   }
 
   getTrades (space, args, cb) {
@@ -322,7 +322,7 @@ class ReportService extends Api {
           symbPropName: 'symbol'
         }
       )
-    }, 'getTrades', cb)
+    }, 'getTrades', args, cb)
   }
 
   getFundingTrades (space, args, cb) {
@@ -335,7 +335,7 @@ class ReportService extends Api {
           symbPropName: 'symbol'
         }
       )
-    }, 'getFundingTrades', cb)
+    }, 'getFundingTrades', args, cb)
   }
 
   getPublicTrades (space, args, cb) {
@@ -352,7 +352,7 @@ class ReportService extends Api {
           datePropName: 'mts'
         }
       )
-    }, 'getPublicTrades', cb)
+    }, 'getPublicTrades', args, cb)
   }
 
   getStatusMessages (space, args, cb) {
@@ -381,7 +381,7 @@ class ReportService extends Api {
           symbPropName: 'key'
         }
       )
-    }, 'getStatusMessages', cb)
+    }, 'getStatusMessages', args, cb)
   }
 
   getCandles (space, args, cb) {
@@ -408,7 +408,7 @@ class ReportService extends Api {
           datePropName: 'mts'
         }
       )
-    }, 'getCandles', cb)
+    }, 'getCandles', args, cb)
   }
 
   getOrderTrades (space, args, cb) {
@@ -421,7 +421,7 @@ class ReportService extends Api {
           symbPropName: 'symbol'
         }
       )
-    }, 'getOrderTrades', cb)
+    }, 'getOrderTrades', args, cb)
   }
 
   getOrders (space, args, cb) {
@@ -438,7 +438,7 @@ class ReportService extends Api {
           )
         }
       )
-    }, 'getOrders', cb)
+    }, 'getOrders', args, cb)
   }
 
   getActiveOrders (space, args, cb) {
@@ -448,7 +448,7 @@ class ReportService extends Api {
       const _res = await rest.activeOrders()
 
       return parseFields(_res, { executed: true })
-    }, 'getActiveOrders', cb)
+    }, 'getActiveOrders', args, cb)
   }
 
   getMovements (space, args, cb) {
@@ -461,7 +461,7 @@ class ReportService extends Api {
           symbPropName: 'currency'
         }
       )
-    }, 'getMovements', cb)
+    }, 'getMovements', args, cb)
   }
 
   getFundingOfferHistory (space, args, cb) {
@@ -478,7 +478,7 @@ class ReportService extends Api {
           )
         }
       )
-    }, 'getFundingOfferHistory', cb)
+    }, 'getFundingOfferHistory', args, cb)
   }
 
   getFundingLoanHistory (space, args, cb) {
@@ -495,7 +495,7 @@ class ReportService extends Api {
           )
         }
       )
-    }, 'getFundingLoanHistory', cb)
+    }, 'getFundingLoanHistory', args, cb)
   }
 
   getFundingCreditHistory (space, args, cb) {
@@ -512,7 +512,7 @@ class ReportService extends Api {
           )
         }
       )
-    }, 'getFundingCreditHistory', cb)
+    }, 'getFundingCreditHistory', args, cb)
   }
 
   getAccountSummary (space, args, cb) {
@@ -523,7 +523,7 @@ class ReportService extends Api {
       const res = await rest.accountSummary()
 
       return Array.isArray(res) ? res : [res]
-    }, 'getAccountSummary', cb)
+    }, 'getAccountSummary', args, cb)
   }
 
   getLogins (space, args, cb) {
@@ -536,7 +536,7 @@ class ReportService extends Api {
           parseFieldsFn: parseLoginsExtraDataFields
         }
       )
-    }, 'getLogins', cb)
+    }, 'getLogins', args, cb)
   }
 
   getChangeLogs (space, args, cb) {
@@ -548,7 +548,7 @@ class ReportService extends Api {
           datePropName: 'mtsCreate'
         }
       )
-    }, 'getChangeLogs', cb)
+    }, 'getChangeLogs', args, cb)
   }
 
   getMultipleCsv (space, args, cb) {
@@ -557,7 +557,7 @@ class ReportService extends Api {
         'getMultipleCsvJobData',
         args
       )
-    }, 'getMultipleCsv', cb)
+    }, 'getMultipleCsv', args, cb)
   }
 
   getTradesCsv (space, args, cb) {
@@ -566,7 +566,7 @@ class ReportService extends Api {
         'getTradesCsvJobData',
         args
       )
-    }, 'getTradesCsv', cb)
+    }, 'getTradesCsv', args, cb)
   }
 
   getFundingTradesCsv (space, args, cb) {
@@ -575,7 +575,7 @@ class ReportService extends Api {
         'getFundingTradesCsvJobData',
         args
       )
-    }, 'getFundingTradesCsv', cb)
+    }, 'getFundingTradesCsv', args, cb)
   }
 
   getTickersHistoryCsv (space, args, cb) {
@@ -584,7 +584,7 @@ class ReportService extends Api {
         'getTickersHistoryCsvJobData',
         args
       )
-    }, 'getTickersHistoryCsv', cb)
+    }, 'getTickersHistoryCsv', args, cb)
   }
 
   getWalletsCsv (space, args, cb) {
@@ -593,7 +593,7 @@ class ReportService extends Api {
         'getWalletsCsvJobData',
         args
       )
-    }, 'getWalletsCsv', cb)
+    }, 'getWalletsCsv', args, cb)
   }
 
   getPositionsHistoryCsv (space, args, cb) {
@@ -602,7 +602,7 @@ class ReportService extends Api {
         'getPositionsHistoryCsvJobData',
         args
       )
-    }, 'getPositionsHistoryCsv', cb)
+    }, 'getPositionsHistoryCsv', args, cb)
   }
 
   getActivePositionsCsv (space, args, cb) {
@@ -611,7 +611,7 @@ class ReportService extends Api {
         'getActivePositionsCsvJobData',
         args
       )
-    }, 'getActivePositionsCsv', cb)
+    }, 'getActivePositionsCsv', args, cb)
   }
 
   getPositionsAuditCsv (space, args, cb) {
@@ -620,7 +620,7 @@ class ReportService extends Api {
         'getPositionsAuditCsvJobData',
         args
       )
-    }, 'getPositionsAuditCsv', cb)
+    }, 'getPositionsAuditCsv', args, cb)
   }
 
   getPublicTradesCsv (space, args, cb) {
@@ -629,7 +629,7 @@ class ReportService extends Api {
         'getPublicTradesCsvJobData',
         args
       )
-    }, 'getPublicTradesCsv', cb)
+    }, 'getPublicTradesCsv', args, cb)
   }
 
   getStatusMessagesCsv (space, args, cb) {
@@ -638,7 +638,7 @@ class ReportService extends Api {
         'getStatusMessagesCsvJobData',
         args
       )
-    }, 'getStatusMessagesCsv', cb)
+    }, 'getStatusMessagesCsv', args, cb)
   }
 
   getCandlesCsv (space, args, cb) {
@@ -647,7 +647,7 @@ class ReportService extends Api {
         'getCandlesCsvJobData',
         args
       )
-    }, 'getCandlesCsv', cb)
+    }, 'getCandlesCsv', args, cb)
   }
 
   getLedgersCsv (space, args, cb) {
@@ -656,7 +656,7 @@ class ReportService extends Api {
         'getLedgersCsvJobData',
         args
       )
-    }, 'getLedgersCsv', cb)
+    }, 'getLedgersCsv', args, cb)
   }
 
   getOrderTradesCsv (space, args, cb) {
@@ -665,7 +665,7 @@ class ReportService extends Api {
         'getOrderTradesCsvJobData',
         args
       )
-    }, 'getOrderTradesCsv', cb)
+    }, 'getOrderTradesCsv', args, cb)
   }
 
   getOrdersCsv (space, args, cb) {
@@ -674,7 +674,7 @@ class ReportService extends Api {
         'getOrdersCsvJobData',
         args
       )
-    }, 'getOrdersCsv', cb)
+    }, 'getOrdersCsv', args, cb)
   }
 
   getActiveOrdersCsv (space, args, cb) {
@@ -683,7 +683,7 @@ class ReportService extends Api {
         'getActiveOrdersCsvJobData',
         args
       )
-    }, 'getActiveOrdersCsv', cb)
+    }, 'getActiveOrdersCsv', args, cb)
   }
 
   getMovementsCsv (space, args, cb) {
@@ -692,7 +692,7 @@ class ReportService extends Api {
         'getMovementsCsvJobData',
         args
       )
-    }, 'getMovementsCsv', cb)
+    }, 'getMovementsCsv', args, cb)
   }
 
   getFundingOfferHistoryCsv (space, args, cb) {
@@ -701,7 +701,7 @@ class ReportService extends Api {
         'getFundingOfferHistoryCsvJobData',
         args
       )
-    }, 'getFundingOfferHistoryCsv', cb)
+    }, 'getFundingOfferHistoryCsv', args, cb)
   }
 
   getFundingLoanHistoryCsv (space, args, cb) {
@@ -710,7 +710,7 @@ class ReportService extends Api {
         'getFundingLoanHistoryCsvJobData',
         args
       )
-    }, 'getFundingLoanHistoryCsv', cb)
+    }, 'getFundingLoanHistoryCsv', args, cb)
   }
 
   getFundingCreditHistoryCsv (space, args, cb) {
@@ -719,7 +719,7 @@ class ReportService extends Api {
         'getFundingCreditHistoryCsvJobData',
         args
       )
-    }, 'getFundingCreditHistoryCsv', cb)
+    }, 'getFundingCreditHistoryCsv', args, cb)
   }
 
   getLoginsCsv (space, args, cb) {
@@ -728,7 +728,7 @@ class ReportService extends Api {
         'getLoginsCsvJobData',
         args
       )
-    }, 'getLoginsCsv', cb)
+    }, 'getLoginsCsv', args, cb)
   }
 
   getChangeLogsCsv (space, args, cb) {
@@ -737,7 +737,7 @@ class ReportService extends Api {
         'getChangeLogsCsvJobData',
         args
       )
-    }, 'getChangeLogsCsv', cb)
+    }, 'getChangeLogsCsv', args, cb)
   }
 }
 


### PR DESCRIPTION
Rework JSON-RPC response

This PR reworks `JSON-RPC` response to follow `JSON-RPC v2.0` specification
https://www.jsonrpc.org/specification
The idea is: send a status code and status message in the grenache service in JSON. And express would just proxy it. To have all logic in one place related to detecting and logging errors
Base changes:
  - Reworks `JSON-RPC` response
  - Reworks common error classes
  - Fixes corresponding test cases

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-report-express/pull/16