### PR TITLE
Add payment to invoice list

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -831,6 +831,7 @@ describe('API', () => {
       'status',
       'customerInfo',
       'invoices',
+      'payment',
       'merchantName'
     ])
   })

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -701,6 +701,17 @@ module.exports = new Map([
             }
           }
         ],
+        payment: {
+          txid: '1234567890qwerty',
+          amount: 0.123123,
+          currency: 'UST',
+          method: 'TETHERUSE',
+          status: 'COMPLETED',
+          confirmations: 5,
+          created_at: '2021-09-12 03:03:03',
+          updated_at: '2021-09-12 03:03:03',
+          depositId: 1234321
+        },
         merchantName: 'Testing'
       }
     ]


### PR DESCRIPTION
This PR adds `payment` to the `invoice list`
Payment example:

```jsonc
payment: {
          txid: '1234567890qwerty',
          amount: 0.123123,
          currency: 'UST',
          method: 'TETHERUSE',
          status: 'COMPLETED',
          confirmations: 5,
          created_at: '2021-09-12 03:03:03',
          updated_at: '2021-09-12 03:03:03',
          depositId: 1234321
        }
```