### PR TITLE
Add ability to send worker error via ipc

### DIFF
--- a/workers/loc.api/logger/index.js
+++ b/workers/loc.api/logger/index.js
@@ -2,6 +2,7 @@
 
 require('colors')
 const os = require('os')
+const util = require('util')
 const path = require('path')
 const argv = require('yargs').argv
 const {
@@ -195,7 +196,10 @@ const _getRestMess = (args = []) => {
 
   try {
     for (const item of args) {
-      restMess = `${restMess} ${item.toString()}`
+      const str = item && typeof item === 'object'
+        ? util.format('%o', item)
+        : item.toString()
+      restMess = `${restMess} ${str}`
     }
   } catch (err) {}
 


### PR DESCRIPTION
This PR adds ability to send worker errors via ipc for the error manager of the `bfx-report-electron`. It is useful when the worker gets an error and tries to log via the `winston`. In this case, send the error to show modal dialog (on the electron side) and ask a user to open a new GitHub issue. Also adds ability to log all arguments logging via the `winston`