### PR TITLE
Add save-exact flag to npm config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+save-exact=true


### PR DESCRIPTION
This PR adds a `save-exact=true` flag to the npm config to have the following:
  - dependencies saved to package.json will be configured with an exact version rather than using npm's default semver range operator https://docs.npmjs.com/cli/v8/using-npm/config#save-exact