### PR TITLE
Handle net disconnection errors

### DIFF
--- a/workers/loc.api/helpers/api-errors-testers.js
+++ b/workers/loc.api/helpers/api-errors-testers.js
@@ -24,11 +24,16 @@ const isENetUnreachError = (err) => {
   return /ENETUNREACH/.test(err.toString())
 }
 
+const isEConnResetError = (err) => {
+  return /ECONNRESET/.test(err.toString())
+}
+
 module.exports = {
   isAuthError,
   isRateLimitError,
   isNonceSmallError,
   isUserIsNotMerchantError,
   isSymbolInvalidError,
-  isENetUnreachError
+  isENetUnreachError,
+  isEConnResetError
 }

--- a/workers/loc.api/helpers/api-errors-testers.js
+++ b/workers/loc.api/helpers/api-errors-testers.js
@@ -44,13 +44,18 @@ const isENotFoundError = (err) => {
   return /ENOTFOUND/.test(err.toString())
 }
 
+const isESocketTimeoutError = (err) => {
+  return /ESOCKETTIMEDOUT/.test(err.toString())
+}
+
 const isENetError = (err) => (
   isENetUnreachError(err) ||
   isEConnResetError(err) ||
   isETimedOutError(err) ||
   isEAiAgainError(err) ||
   isEConnRefusedError(err) ||
-  isENotFoundError(err)
+  isENotFoundError(err) ||
+  isESocketTimeoutError(err)
 )
 
 module.exports = {
@@ -65,5 +70,6 @@ module.exports = {
   isEAiAgainError,
   isEConnRefusedError,
   isENotFoundError,
+  isESocketTimeoutError,
   isENetError
 }

--- a/workers/loc.api/helpers/api-errors-testers.js
+++ b/workers/loc.api/helpers/api-errors-testers.js
@@ -44,6 +44,15 @@ const isENotFoundError = (err) => {
   return /ENOTFOUND/.test(err.toString())
 }
 
+const isENetError = (err) => (
+  isENetUnreachError(err) ||
+  isEConnResetError(err) ||
+  isETimedOutError(err) ||
+  isEAiAgainError(err) ||
+  isEConnRefusedError(err) ||
+  isENotFoundError(err)
+)
+
 module.exports = {
   isAuthError,
   isRateLimitError,
@@ -55,5 +64,6 @@ module.exports = {
   isETimedOutError,
   isEAiAgainError,
   isEConnRefusedError,
-  isENotFoundError
+  isENotFoundError,
+  isENetError
 }

--- a/workers/loc.api/helpers/api-errors-testers.js
+++ b/workers/loc.api/helpers/api-errors-testers.js
@@ -28,6 +28,10 @@ const isEConnResetError = (err) => {
   return /ECONNRESET/.test(err.toString())
 }
 
+const isETimedOutError = (err) => {
+  return /ETIMEDOUT/.test(err.toString())
+}
+
 module.exports = {
   isAuthError,
   isRateLimitError,
@@ -35,5 +39,6 @@ module.exports = {
   isUserIsNotMerchantError,
   isSymbolInvalidError,
   isENetUnreachError,
-  isEConnResetError
+  isEConnResetError,
+  isETimedOutError
 }

--- a/workers/loc.api/helpers/api-errors-testers.js
+++ b/workers/loc.api/helpers/api-errors-testers.js
@@ -20,10 +20,15 @@ const isSymbolInvalidError = (err) => {
   return /(symbol: invalid)|(currency: invalid)/.test(err.toString())
 }
 
+const isENetUnreachError = (err) => {
+  return /ENETUNREACH/.test(err.toString())
+}
+
 module.exports = {
   isAuthError,
   isRateLimitError,
   isNonceSmallError,
   isUserIsNotMerchantError,
-  isSymbolInvalidError
+  isSymbolInvalidError,
+  isENetUnreachError
 }

--- a/workers/loc.api/helpers/api-errors-testers.js
+++ b/workers/loc.api/helpers/api-errors-testers.js
@@ -32,6 +32,10 @@ const isETimedOutError = (err) => {
   return /ETIMEDOUT/.test(err.toString())
 }
 
+const isEAiAgainError = (err) => {
+  return /EAI_AGAIN/.test(err.toString())
+}
+
 module.exports = {
   isAuthError,
   isRateLimitError,
@@ -40,5 +44,6 @@ module.exports = {
   isSymbolInvalidError,
   isENetUnreachError,
   isEConnResetError,
-  isETimedOutError
+  isETimedOutError,
+  isEAiAgainError
 }

--- a/workers/loc.api/helpers/api-errors-testers.js
+++ b/workers/loc.api/helpers/api-errors-testers.js
@@ -40,6 +40,10 @@ const isEConnRefusedError = (err) => {
   return /ECONNREFUSED/.test(err.toString())
 }
 
+const isENotFoundError = (err) => {
+  return /ENOTFOUND/.test(err.toString())
+}
+
 module.exports = {
   isAuthError,
   isRateLimitError,
@@ -50,5 +54,6 @@ module.exports = {
   isEConnResetError,
   isETimedOutError,
   isEAiAgainError,
-  isEConnRefusedError
+  isEConnRefusedError,
+  isENotFoundError
 }

--- a/workers/loc.api/helpers/api-errors-testers.js
+++ b/workers/loc.api/helpers/api-errors-testers.js
@@ -36,6 +36,10 @@ const isEAiAgainError = (err) => {
   return /EAI_AGAIN/.test(err.toString())
 }
 
+const isEConnRefusedError = (err) => {
+  return /ECONNREFUSED/.test(err.toString())
+}
+
 module.exports = {
   isAuthError,
   isRateLimitError,
@@ -45,5 +49,6 @@ module.exports = {
   isENetUnreachError,
   isEConnResetError,
   isETimedOutError,
-  isEAiAgainError
+  isEAiAgainError,
+  isEConnRefusedError
 }

--- a/workers/loc.api/helpers/get-data-from-api.js
+++ b/workers/loc.api/helpers/get-data-from-api.js
@@ -8,7 +8,8 @@ const {
   isNonceSmallError,
   isUserIsNotMerchantError,
   isENetUnreachError,
-  isEConnResetError
+  isEConnResetError,
+  isETimedOutError
 } = require('./api-errors-testers')
 
 const _delay = (mc = 80000, interrupter) => {
@@ -119,7 +120,8 @@ module.exports = async (
       }
       if (
         isENetUnreachError(err) ||
-        isEConnResetError(err)
+        isEConnResetError(err) ||
+        isETimedOutError(err)
       ) {
         countNetError += 1
 

--- a/workers/loc.api/helpers/get-data-from-api.js
+++ b/workers/loc.api/helpers/get-data-from-api.js
@@ -7,9 +7,7 @@ const {
   isRateLimitError,
   isNonceSmallError,
   isUserIsNotMerchantError,
-  isENetUnreachError,
-  isEConnResetError,
-  isETimedOutError
+  isENetError
 } = require('./api-errors-testers')
 
 const _delay = (mc = 80000, interrupter) => {
@@ -118,11 +116,7 @@ module.exports = async (
 
         continue
       }
-      if (
-        isENetUnreachError(err) ||
-        isEConnResetError(err) ||
-        isETimedOutError(err)
-      ) {
+      if (isENetError(err)) {
         countNetError += 1
 
         const timeframe = 10 // min

--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -31,6 +31,7 @@ const {
   isEAiAgainError,
   isEConnRefusedError,
   isENotFoundError,
+  isESocketTimeoutError,
   isENetError
 } = require('./api-errors-testers')
 const {
@@ -69,6 +70,7 @@ module.exports = {
   isEAiAgainError,
   isEConnRefusedError,
   isENotFoundError,
+  isESocketTimeoutError,
   isENetError,
   accountCache,
   parseFields,

--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -24,7 +24,14 @@ const {
   isRateLimitError,
   isNonceSmallError,
   isUserIsNotMerchantError,
-  isSymbolInvalidError
+  isSymbolInvalidError,
+  isENetUnreachError,
+  isEConnResetError,
+  isETimedOutError,
+  isEAiAgainError,
+  isEConnRefusedError,
+  isENotFoundError,
+  isENetError
 } = require('./api-errors-testers')
 const {
   accountCache,
@@ -56,6 +63,13 @@ module.exports = {
   isNonceSmallError,
   isUserIsNotMerchantError,
   isSymbolInvalidError,
+  isENetUnreachError,
+  isEConnResetError,
+  isETimedOutError,
+  isEAiAgainError,
+  isEConnRefusedError,
+  isENotFoundError,
+  isENetError,
   accountCache,
   parseFields,
   parseLoginsExtraDataFields,


### PR DESCRIPTION
This PR adds the ability to handle the common network disconnection errors to be able to continue the sync process if the internet connection is failed and then restored for not more than 10 min (will try to get data again at intervals of 10 sec)

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-api-node-rest/pull/95