### PR TITLE
Add Portuguese translations to emails

### DIFF
--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -56,7 +56,7 @@ const dateFormat = {
 }
 const language = {
   type: 'string',
-  enum: ['en', 'ru', 'zh-CN', 'zh-TW', 'es-EM', 'tr']
+  enum: ['en', 'ru', 'zh-CN', 'zh-TW', 'es-EM', 'tr', 'pt-PT']
 }
 
 const paramsSchemaForPayInvoiceList = {

--- a/workers/loc.api/queue/send-mail/translations/email.yml
+++ b/workers/loc.api/queue/send-mail/translations/email.yml
@@ -81,3 +81,17 @@ tr:
     youCan: Yapabilirsiniz
     download: indir
     pgpSignature: bir PGP dijital imza dosyası
+
+pt-PT:
+  template:
+    subject: Seu relatório está pronto
+    btnText: Baixar CSV
+    fileName: Nome do arquivo
+    unauth: Não foi possível concluir seu arquivo, tente novamente
+    readyForDownload: O relatório solicitado está pronto para download
+    ifDidNotInitAction: Se você não iniciou esta ação e suspeita que sua conta pode estar comprometida
+    freezeAccount: por favor, congele sua conta
+    contactSupport: e entre em contato com o suporte
+    youCan: Você pode
+    download: baixar
+    pgpSignature: um arquivo de assinatura digital PGP


### PR DESCRIPTION
This PR adds Portuguese translations to emails

Request example:

```jsonc
{
    "auth": {
        "apiKey": "api-key",
        "apiSecret": "api-secret"
    },
    "method": "getLedgersCsv",
    "params": {
      "limit": 20,
      "email": "user@mail.com",
      "language": "pt-PT"
    }
}
```

Email example:

![Screenshot from 2022-03-01 15-09-15](https://user-images.githubusercontent.com/16489235/156174763-60d827dc-1db7-48e7-ba79-04023e9db40e.png)

**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-ext-sendgrid-js/pull/22
