### PR TITLE
Fix symbol pair splitting

### DIFF
--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -13,7 +13,8 @@ const {
   getREST,
   grcBfxReq,
   prepareResponse,
-  prepareApiResponse
+  prepareApiResponse,
+  FOREX_SYMBS
 } = require('../helpers')
 const HasGrcService = require('../has.grc.service')
 const processor = require('../queue/processor')
@@ -86,6 +87,7 @@ module.exports = ({
         [TYPES.GetREST]
       )
     )
+    bind(TYPES.FOREX_SYMBS).toConstantValue(FOREX_SYMBS)
     bind(TYPES.Link).toConstantValue(link)
     bind(TYPES.HasGrcService)
       .to(HasGrcService)

--- a/workers/loc.api/di/types.js
+++ b/workers/loc.api/di/types.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   CONF: Symbol.for('CONF'),
+  FOREX_SYMBS: Symbol.for('FOREX_SYMBS'),
   RootPath: Symbol.for('RootPath'),
   Container: Symbol.for('Container'),
   LoggerFactory: Symbol.for('LoggerFactory'),

--- a/workers/loc.api/helpers/__test__/split-symbol-pairs.spec.js
+++ b/workers/loc.api/helpers/__test__/split-symbol-pairs.spec.js
@@ -38,6 +38,17 @@ describe('splitSymbolPairs helper', () => {
     assert.strictEqual(res[1], 'USD')
   })
 
+  it('BTCEOS pair', function () {
+    this.timeout(1000)
+
+    const res = splitSymbolPairs('BTCEOS')
+
+    assert.isArray(res)
+    assert.lengthOf(res, 2)
+    assert.strictEqual(res[0], 'BTC')
+    assert.strictEqual(res[1], 'EOS')
+  })
+
   it('tXAUT:USD pair', function () {
     this.timeout(1000)
 
@@ -102,5 +113,35 @@ describe('splitSymbolPairs helper', () => {
     assert.lengthOf(res, 2)
     assert.strictEqual(res[0], 'EUR')
     assert.strictEqual(res[1], 'USD')
+  })
+
+  it('MATIC coin, without separator', function () {
+    this.timeout(1000)
+
+    const res = splitSymbolPairs('MATIC')
+
+    assert.isArray(res)
+    assert.lengthOf(res, 1)
+    assert.strictEqual(res[0], 'MATIC')
+  })
+
+  it('MATICM coin, without separator', function () {
+    this.timeout(1000)
+
+    const res = splitSymbolPairs('MATICM')
+
+    assert.isArray(res)
+    assert.lengthOf(res, 1)
+    assert.strictEqual(res[0], 'MATICM')
+  })
+
+  it('MATICMF0 coin, without separator', function () {
+    this.timeout(1000)
+
+    const res = splitSymbolPairs('MATICMF0')
+
+    assert.isArray(res)
+    assert.lengthOf(res, 1)
+    assert.strictEqual(res[0], 'MATICMF0')
   })
 })

--- a/workers/loc.api/helpers/__test__/split-symbol-pairs.spec.js
+++ b/workers/loc.api/helpers/__test__/split-symbol-pairs.spec.js
@@ -125,6 +125,17 @@ describe('splitSymbolPairs helper', () => {
     assert.strictEqual(res[0], 'MATIC')
   })
 
+  it('tMATIC:USD pair, without separator', function () {
+    this.timeout(1000)
+
+    const res = splitSymbolPairs('tMATIC:USD')
+
+    assert.isArray(res)
+    assert.lengthOf(res, 2)
+    assert.strictEqual(res[0], 'MATIC')
+    assert.strictEqual(res[1], 'USD')
+  })
+
   it('MATICM coin, without separator', function () {
     this.timeout(1000)
 

--- a/workers/loc.api/helpers/forex.symbs.js
+++ b/workers/loc.api/helpers/forex.symbs.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = ['EUR', 'JPY', 'GBP', 'USD']

--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -52,6 +52,7 @@ const FILTER_MODELS_NAMES = require('./filter.models.names')
 const FILTER_CONDITIONS = require('./filter.conditions')
 const getDataFromApi = require('./get-data-from-api')
 const splitSymbolPairs = require('./split-symbol-pairs')
+const FOREX_SYMBS = require('./forex.symbs')
 
 module.exports = {
   getREST,
@@ -91,5 +92,6 @@ module.exports = {
   FILTER_CONDITIONS,
   getDataFromApi,
   parsePositionsAuditId,
-  splitSymbolPairs
+  splitSymbolPairs,
+  FOREX_SYMBS
 }

--- a/workers/loc.api/helpers/split-symbol-pairs.js
+++ b/workers/loc.api/helpers/split-symbol-pairs.js
@@ -1,16 +1,58 @@
 'use strict'
 
-module.exports = (symbol) => {
-  const str = (
-    symbol[0] === 't' ||
-    symbol[0] === 'f'
+const FOREX_SYMBS = require('./forex.symbs')
+
+const detectingSymbs = [
+  'BTC',
+  ...FOREX_SYMBS
+]
+
+/* It allows to cover pairs with str length 6 and without `t` and `f` prefixes
+ * for currency converter of bfx-reports-framework used to triangulation:
+ * `BTCUSD`, `BTCEOS` etc
+ */
+const isNotSymbContained = (
+  currSymb,
+  symbs = detectingSymbs
+) => {
+  return (
+    Array.isArray(symbs) &&
+    symbs.every((symb) => (
+      !currSymb.startsWith(symb) &&
+      !currSymb.endsWith(symb)
+    ))
   )
+}
+
+const _startsWithPrefix = (str) => (
+  str.startsWith('t') ||
+  str.startsWith('f')
+)
+
+const _containsSeparator = (str) => (
+  /.+[:].+/.test(str)
+)
+
+module.exports = (symbol) => {
+  const hasPrefix = _startsWithPrefix(symbol)
+  const hasSeparator = _containsSeparator(symbol)
+
+  if (
+    !hasPrefix &&
+    !hasSeparator &&
+    symbol.length > 5 &&
+    isNotSymbContained(symbol)
+  ) {
+    return [symbol]
+  }
+
+  const str = hasPrefix
     ? symbol.slice(1)
     : symbol
 
   if (
     str.length > 5 &&
-    /.+[:].+/.test(str)
+    hasSeparator
   ) {
     return str.split(':')
   }


### PR DESCRIPTION
This PR fixes symbol pair splitting. Basic changes:
  - handles pairs with long characters like `tMATICM:USD`, `MATICMF0` etc
  - adds corresponding test coverage
  