### PR TITLE
Use inner max limit for internal public api calls

### DIFF
--- a/workers/loc.api/helpers/limit-param.helpers.js
+++ b/workers/loc.api/helpers/limit-param.helpers.js
@@ -36,8 +36,16 @@ const getMethodLimit = (sendLimit, method, methodsLimits = {}) => {
   } = selectedMethod
   const {
     isMax,
-    isInnerMax
+    isInnerMax,
+    isNotMoreThanInnerMax
   } = { ...sendLimit }
+
+  const limit = Number.isInteger(sendLimit?.limit)
+    ? sendLimit?.limit
+    : sendLimit
+  const base = Number.isInteger(limit)
+    ? limit
+    : defVal
 
   if (isInnerMax) {
     return innerMax
@@ -45,10 +53,9 @@ const getMethodLimit = (sendLimit, method, methodsLimits = {}) => {
   if (isMax) {
     return max
   }
-
-  const base = Number.isInteger(sendLimit)
-    ? sendLimit
-    : defVal
+  if (isNotMoreThanInnerMax) {
+    return getLimitNotMoreThan(base, innerMax)
+  }
 
   return getLimitNotMoreThan(base, max)
 }

--- a/workers/loc.api/helpers/prepare-response.js
+++ b/workers/loc.api/helpers/prepare-response.js
@@ -250,10 +250,10 @@ const _getParams = (
   }
 
   const { params } = { ...args }
-  const { isInnerMax } = { ...opts }
+  const { isInnerMax, isNotMoreThanInnerMax } = { ...opts }
   const limit = isInnerMax
     ? { isInnerMax }
-    : params.limit
+    : { limit: params.limit, isNotMoreThanInnerMax }
   const paramsObj = {
     ...cloneDeep(params),
     end: getDateNotMoreNow(params.end),
@@ -329,11 +329,15 @@ const _isNotContainedSameMts = (
     return false
   }
 
-  const { isMax = true, isInnerMax } = { ...opts }
+  const {
+    isMax = true,
+    isInnerMax,
+    isNotMoreThanInnerMax
+  } = { ...opts }
   const firstElem = { ...apiRes[0] }
   const mts = firstElem[datePropName]
   const methodLimit = getMethodLimit(
-    { isMax, isInnerMax },
+    { isMax, isInnerMax, isNotMoreThanInnerMax },
     methodApi
   )
 
@@ -484,7 +488,8 @@ const prepareApiResponse = (
     datePropName,
     symbPropName,
     requireFields,
-    parseFieldsFn
+    parseFieldsFn,
+    isNotMoreThanInnerMax
   } = { ...params }
   const schemaName = _getSchemaNameByMethodName(methodApi)
 
@@ -498,17 +503,19 @@ const prepareApiResponse = (
     getREST,
     args,
     methodApi,
-    symbPropName
+    symbPropName,
+    { isNotMoreThanInnerMax }
   )
   const isNotContainedSameMts = _isNotContainedSameMts(
     resData.apiRes,
     methodApi,
     datePropName,
-    resData.paramsObj.limit
+    resData.paramsObj.limit,
+    { isNotMoreThanInnerMax }
   )
   const opts = isNotContainedSameMts
-    ? { isMax: true }
-    : { isInnerMax: true }
+    ? { isMax: true, isNotMoreThanInnerMax }
+    : { isInnerMax: true, isNotMoreThanInnerMax }
   const {
     apiRes,
     paramsObj

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -226,7 +226,11 @@ class ReportService extends Api {
 
   getTickersHistory (space, args, cb) {
     return this._responder(() => {
-      const { symbol: s } = { ...args.params }
+      const {
+        params,
+        isNotMoreThanInnerMax
+      } = args ?? {}
+      const { symbol: s } = params ?? {}
       const symbol = s && typeof s === 'string'
         ? [s]
         : s
@@ -244,7 +248,8 @@ class ReportService extends Api {
         'tickersHistory',
         {
           datePropName: 'mtsUpdate',
-          requireFields: ['symbol']
+          requireFields: ['symbol'],
+          isNotMoreThanInnerMax
         }
       )
     }, 'getTickersHistory', args, cb)
@@ -353,6 +358,7 @@ class ReportService extends Api {
 
   getPublicTrades (space, args, cb) {
     return this._responder(() => {
+      const { isNotMoreThanInnerMax } = args ?? {}
       const _args = {
         ...args,
         auth: {}
@@ -362,7 +368,8 @@ class ReportService extends Api {
         _args,
         'publicTrades',
         {
-          datePropName: 'mts'
+          datePropName: 'mts',
+          isNotMoreThanInnerMax
         }
       )
     }, 'getPublicTrades', args, cb)
@@ -399,11 +406,14 @@ class ReportService extends Api {
 
   getCandles (space, args, cb) {
     return this._responder(() => {
-      const { params } = { ...args }
+      const {
+        params,
+        isNotMoreThanInnerMax
+      } = args ?? {}
       const {
         section = 'hist',
         timeframe = '1D'
-      } = { ...params }
+      } = params ?? {}
       const _args = {
         ...args,
         auth: {},
@@ -418,7 +428,8 @@ class ReportService extends Api {
         _args,
         'candles',
         {
-          datePropName: 'mts'
+          datePropName: 'mts',
+          isNotMoreThanInnerMax
         }
       )
     }, 'getCandles', args, cb)


### PR DESCRIPTION
This PR adds ability to set request limits for public API calls not more than the inner max limit: https://github.com/bitfinexcom/bfx-report/blob/cc53f7744d703cee26a88d320367b90543c9f4d3/workers/loc.api/helpers/limit-param.helpers.js#L19
This relaxation of the restriction is useful for internal requests to avoid the frequent occurrence of the rate limit error

Request example:
```json
{
  "auth": {
    "token": "user-token"
  },
  "method": "getCandles",
  "params": {
    "start": 1651363200000,
    "end": 1654041600000,
    "timeframe": "1h",
    "symbol": "tBTCUSD",
    "limit": 10000
  },
  "isNotMoreThanInnerMax": true
}
```