### PR TITLE
Add orders metadata to csv

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -1356,7 +1356,9 @@ describe('API', () => {
       'priceAuxLimit',
       'notify',
       'placedId',
-      'amountExecuted'
+      'amountExecuted',
+      'routing',
+      'meta'
     ])
   })
 

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -305,7 +305,13 @@ module.exports = new Map([
       null,
       false,
       null,
-      null
+      null,
+      null,
+      null,
+      'BFX',
+      null,
+      null,
+      { _$F7: 1 }
     ]]
   ],
   [

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -654,7 +654,8 @@ class CsvJobData {
         priceTrailing: 'TRAILING PRICE',
         mtsCreate: 'CREATED',
         mtsUpdate: 'UPDATED',
-        status: 'STATUS'
+        status: 'STATUS',
+        meta: 'METADATA'
       },
       formatSettings: {
         mtsUpdate: 'date',


### PR DESCRIPTION
This PR adds orders metadata to csv export and also adds ones to the corresponding test case