### PR TITLE
Add string rate normalization to csv export

### DIFF
--- a/workers/loc.api/generate-csv/index.js
+++ b/workers/loc.api/generate-csv/index.js
@@ -1,10 +1,14 @@
 'use strict'
 
-const { upperFirst } = require('lodash')
+const {
+  upperFirst,
+  lowerFirst
+} = require('lodash')
 
 const {
   checkFilterParams,
-  FILTER_MODELS_NAMES
+  FILTER_MODELS_NAMES,
+  normalizeFilterParams
 } = require('../helpers')
 const {
   EmailSendingError
@@ -61,12 +65,22 @@ const _filterModelNameMap = Object.values(FILTER_MODELS_NAMES)
     return map
   }, new Map())
 
+const _truncateCsvNameEnding = (name) => {
+  const cleanedName = name
+    .replace(/^get/i, '')
+    .replace(/csv$/i, '')
+
+  return lowerFirst(cleanedName)
+}
+
 const _getFilterModelNamesAndArgs = (
   name,
-  args
+  reqArgs
 ) => {
   if (name !== 'getMultipleCsvJobData') {
     const filterModelName = _filterModelNameMap.get(name)
+    const truncatedName = _truncateCsvNameEnding(name)
+    const args = normalizeFilterParams(truncatedName, reqArgs)
 
     return [{
       filterModelName,
@@ -74,7 +88,7 @@ const _getFilterModelNamesAndArgs = (
     }]
   }
 
-  const { params } = { ...args }
+  const { params } = { ...reqArgs }
   const { multiExport } = { ...params }
   const _multiExport = Array.isArray(multiExport)
     ? multiExport
@@ -83,7 +97,8 @@ const _getFilterModelNamesAndArgs = (
   return _multiExport.map((params) => {
     const { method } = { ...params }
     const name = `${method}JobData`
-    const args = { params }
+    const truncatedName = _truncateCsvNameEnding(method)
+    const args = normalizeFilterParams(truncatedName, { params })
     const filterModelName = _filterModelNameMap.get(name)
 
     return {


### PR DESCRIPTION
This PR fixes string `rate` normalization to csv export of `Public Funding`
Earlier we added some normalization for the string `rate` to convert to a number
https://github.com/bitfinexcom/bfx-report/blob/master/workers/loc.api/helpers/prepare-response.js#L497
https://github.com/bitfinexcom/bfx-report/blob/master/workers/loc.api/helpers/normalize-filter-params.js#L64
Need to add the corresponding normalization to csv export to have the same behavior