### PR TITLE
Fix multiple csv export

### DIFF
--- a/workers/loc.api/generate-csv/index.js
+++ b/workers/loc.api/generate-csv/index.js
@@ -66,6 +66,10 @@ const _filterModelNameMap = Object.values(FILTER_MODELS_NAMES)
   }, new Map())
 
 const _truncateCsvNameEnding = (name) => {
+  if (!name) {
+    return name
+  }
+
   const cleanedName = name
     .replace(/^get/i, '')
     .replace(/csv$/i, '')


### PR DESCRIPTION
This PR fixes multiple csv export. It covers test case when a method name is not passed in request args to be sent 400 status error instead of 500: https://github.com/bitfinexcom/bfx-report/blob/master/test/4-queue-base.spec.js#L114