### PR TITLE
Use inner max request limit to api v2 for syncing data

### DIFF
--- a/workers/loc.api/helpers/prepare-response.js
+++ b/workers/loc.api/helpers/prepare-response.js
@@ -489,7 +489,7 @@ const prepareApiResponse = (
     symbPropName,
     requireFields,
     parseFieldsFn,
-    isNotMoreThanInnerMax
+    isNotMoreThanInnerMax: _isNotMoreThanInnerMax
   } = { ...params }
   const schemaName = _getSchemaNameByMethodName(methodApi)
 
@@ -498,6 +498,8 @@ const prepareApiResponse = (
   checkFilterParams(methodApi, args)
 
   const symbols = _getSymbols(methodApi, symbPropName, args)
+  const isSyncRequest = args?.params?.isSyncRequest
+  const isNotMoreThanInnerMax = isSyncRequest || _isNotMoreThanInnerMax
 
   const resData = await _getResAndParams(
     getREST,


### PR DESCRIPTION
This PR adds ability to use the inner max request limit to `api_v2` to seed up syncing data, if pass `isSyncRequest: true` flag to request params it would be used a restriction not more than `innerMax` of this map: https://github.com/bitfinexcom/bfx-report/blob/master/workers/loc.api/helpers/limit-param.helpers.js#L4