### PR TITLE
Improve error handling

### DIFF
--- a/workers/loc.api/helpers/get-data-from-api.js
+++ b/workers/loc.api/helpers/get-data-from-api.js
@@ -79,6 +79,13 @@ module.exports = (
     try {
       const _args = cloneDeep(args)
 
+      /*
+       * API request should not be logged to std error stream
+       * when making an internal call and can have some attempts
+       * due to an internet connection issue
+       */
+      _args.shouldNotBeLoggedToStdErrorStream = true
+
       if (
         typeof getData === 'string' &&
         typeof middleware === 'function'


### PR DESCRIPTION
This PR adds an option to not throw `ENET` error in the case when there are going to make retries to resume the internet connection. API requests should not be logged to `std error` stream when making an internal call and can have some attempts due to an internet connection issue
It's important for sync to avoid showing redundant error modal dialogs in the electron app

Related to the issue https://github.com/bitfinexcom/bfx-report-electron/issues/176