### PR TITLE
Add username/pwd auth support

### DIFF
--- a/workers/loc.api/abstract.ws.event.emitter/index.js
+++ b/workers/loc.api/abstract.ws.event.emitter/index.js
@@ -9,6 +9,13 @@ class AbstractWSEventEmitter {
    */
   async emit (handler, action) { throw new ImplementationError() }
 
+  /**
+   * @abstract
+   */
+  async emitBfxUnamePwdAuthRequiredToOne (handler, auth) {
+    throw new ImplementationError()
+  }
+
   emitENetError (
     handler = () => {},
     action = 'emitENetError'

--- a/workers/loc.api/helpers/get-rest.js
+++ b/workers/loc.api/helpers/get-rest.js
@@ -141,8 +141,17 @@ module.exports = (conf) => {
     const {
       apiKey = '',
       apiSecret = '',
-      authToken = ''
+      authToken: _authToken = ''
     } = auth
+
+    /*
+     * It uses dynamic getter to fetch refreshed auth token
+     * from session in framework mode
+     */
+    const authToken = typeof auth?.authTokenFn === 'function'
+      ? auth.authTokenFn()
+      : _authToken
+
     const _auth = authToken
       ? { authToken }
       : { apiKey, apiSecret }

--- a/workers/loc.api/helpers/get-rest.js
+++ b/workers/loc.api/helpers/get-rest.js
@@ -141,11 +141,10 @@ module.exports = (conf) => {
     const {
       apiKey = '',
       apiSecret = '',
-      authToken = '',
-      ip = ''
+      authToken = ''
     } = auth
     const _auth = authToken
-      ? { authToken, ip }
+      ? { authToken }
       : { apiKey, apiSecret }
 
     const rest = bfxInstance.rest(2, _auth)

--- a/workers/loc.api/responder/index.js
+++ b/workers/loc.api/responder/index.js
@@ -207,7 +207,7 @@ const _makeJsonRpcResponse = (args, result) => {
 module.exports = (
   container,
   logger,
-  wsEventEmitter
+  wsEventEmitterFactory
 ) => (
   handler,
   name,
@@ -215,6 +215,9 @@ module.exports = (
   cb
 ) => {
   const isInternalRequest = !cb
+  const wsEventEmitter = typeof wsEventEmitterFactory === 'function'
+    ? wsEventEmitterFactory()
+    : wsEventEmitterFactory
   const loggerArgs = {
     logger,
     wsEventEmitter,

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -33,6 +33,13 @@ class ReportService extends Api {
     })
   }
 
+  _invalidateAuthToken (args) {
+    const rest = this._getREST(args?.auth)
+    const { authToken } = args?.params ?? {}
+
+    return rest.invalidateAuthToken(authToken)
+  }
+
   _getUserInfo (args) {
     const rest = this._getREST(args.auth)
 
@@ -159,6 +166,12 @@ class ReportService extends Api {
     return this._responder(async () => {
       return this._generateToken(args)
     }, 'generateToken', args, cb)
+  }
+
+  invalidateAuthToken (space, args, cb) {
+    return this._responder(async () => {
+      return this._invalidateAuthToken(args)
+    }, 'invalidateAuthToken', args, cb)
   }
 
   getUsersTimeConf (space, args, cb) {

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -21,6 +21,18 @@ class ReportService extends Api {
     this.container.get(TYPES.InjectDepsToRService)()
   }
 
+  _generateToken (args, opts) {
+    const rest = this._getREST(args?.auth)
+
+    return rest.generateToken({
+      ttl: opts?.ttl ?? 3600,
+      scope: opts?.scope ?? 'api',
+      writePermission: opts?.writePermission ?? false,
+      _cust_ip: opts?._cust_ip ?? '0',
+      ...opts
+    })
+  }
+
   _getUserInfo (args) {
     const rest = this._getREST(args.auth)
 
@@ -145,15 +157,7 @@ class ReportService extends Api {
 
   generateToken (space, args, cb) {
     return this._responder(async () => {
-      const { auth } = { ...args }
-      const rest = this._getREST(auth)
-
-      return rest.generateToken({
-        ttl: 3600,
-        scope: 'api',
-        writePermission: false,
-        _cust_ip: '0'
-      })
+      return this._generateToken(args)
     }, 'generateToken', args, cb)
   }
 


### PR DESCRIPTION
This PR adds corresponding changes to add BFX auth token support to framework mode. Basic changes:
  - Adds `invalidateAuthToken` and `generateToken` endpoints
  - Adds ability to send emitBfxUnamePwdAuthRequiredToOne event by WebSockets in cases if the auth token is expired for the framework mode
  - Adds ability to use dynamic getter to fetch refreshed auth token from a session in the framework mode