### PR TITLE
Send event by ws when csv is ready

### DIFF
--- a/workers/loc.api/queue/aggregator.js
+++ b/workers/loc.api/queue/aggregator.js
@@ -93,7 +93,7 @@ module.exports = (
       }
 
       job.done()
-      aggregatorQueue.emit('completed', { newFilePaths })
+      aggregatorQueue.emit('completed', { newFilePaths, userInfo })
     } catch (err) {
       if (err.syscall === 'unlink') {
         aggregatorQueue.emit('error:unlink', job)

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -157,7 +157,8 @@ class ReportService extends Api {
         timezone,
         email,
         id,
-        isSubAccount: false
+        isSubAccount: false,
+        _id: null // to have the same data structure as in framework mode
       }
     }, 'verifyUser', args, cb)
   }


### PR DESCRIPTION
This PR adds ability to send csv files metadata with the `completed` event of the event emitter of the csv aggregator queue to emit the ones by WS in the framework mode

---

Metadata example:
```jsonc
{
  "csvFilesMetadata": [
    {
      "name": "getLedgers",
      "filePath": "/home/user/projects/bitfinex/bfx-reports-framework/csv/user_ledgers_FROM_Thu-Dec-12-2019_TO_Mon-Feb-06-2023_ON_2023-02-23T10-08-29.785Z.csv"
    },
    {
      "name": "getTrades",
      "filePath": "/home/user/projects/bitfinex/bfx-reports-framework/csv/user_trades_FROM_Thu-Dec-12-2019_TO_Mon-Feb-06-2023_ON_2023-02-23T10-08-29.795Z.csv"
    },
    {
      "name": "getMovements",
      "filePath": "/home/user/projects/bitfinex/bfx-reports-framework/csv/user_movements_FROM_Thu-Dec-12-2019_TO_Mon-Feb-06-2023_ON_2023-02-23T10-08-29.815Z.csv"
    }
  ],
  "userInfo": {
    "_id": 123 // Used to identify a specific user for WS emitting
    // Other user props
  }
}
```