### PR TITLE
Add ability to set options into AuthError

### DIFF
--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -34,8 +34,10 @@ class BadRequestError extends BaseError {
 }
 
 class AuthError extends BaseError {
-  constructor (message = 'ERR_AUTH_UNAUTHORIZED') {
-    super(message)
+  constructor (args) {
+    const _args = getErrorArgs(args, 'ERR_AUTH_UNAUTHORIZED')
+
+    super(_args)
 
     this.statusCode = 401
     this.statusMessage = 'Unauthorized'


### PR DESCRIPTION
This PR adds ability to set options into the AuthError for providing `isAuthTokenGenerationError: true` flag for better UX of 2FA in the framework mode