### PR TITLE
Add weighted averages report to web ver

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -1747,9 +1747,11 @@ describe('API', () => {
 
       assert.isObject(res.body)
       assert.propertyVal(res.body, 'id', 5)
-      assert.isArray(res.body.result)
+      assert.isObject(res.body.result)
+      assert.isArray(res.body.result.res)
+      assert.isBoolean(res.body.result.nextPage)
 
-      const resItem = res.body.result[0]
+      const resItem = res.body.result.res[0]
 
       assert.isObject(resItem)
       assert.containsAllKeys(resItem, [

--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -1719,4 +1719,48 @@ describe('API', () => {
       'note'
     ])
   })
+
+  it('it should be successfully performed by the getWeightedAveragesReport method', async function () {
+    this.timeout(120000)
+
+    const paramsArr = [
+      { end, start },
+      {
+        end,
+        start: end - (10 * 60 * 60 * 1000),
+        symbol: ['tBTCUSD']
+      }
+    ]
+
+    for (const params of paramsArr) {
+      const res = await agent
+        .post(`${basePath}/json-rpc`)
+        .type('json')
+        .send({
+          auth,
+          method: 'getWeightedAveragesReport',
+          params,
+          id: 5
+        })
+        .expect('Content-Type', /json/)
+        .expect(200)
+
+      assert.isObject(res.body)
+      assert.propertyVal(res.body, 'id', 5)
+      assert.isArray(res.body.result)
+
+      const resItem = res.body.result[0]
+
+      assert.isObject(resItem)
+      assert.containsAllKeys(resItem, [
+        'symbol',
+        'buyingWeightedPrice',
+        'buyingAmount',
+        'sellingWeightedPrice',
+        'sellingAmount',
+        'cumulativeWeightedPrice',
+        'cumulativeAmount'
+      ])
+    }
+  })
 })

--- a/test/4-queue-base.spec.js
+++ b/test/4-queue-base.spec.js
@@ -819,6 +819,31 @@ describe('Queue', () => {
     await testMethodOfGettingCsv(procPromise, aggrPromise, res)
   })
 
+  it('it should be successfully performed by the getWeightedAveragesReportCsv method', async function () {
+    this.timeout(60000)
+
+    const procPromise = queueToPromise(processorQueue)
+    const aggrPromise = queueToPromise(aggregatorQueue)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getWeightedAveragesReportCsv',
+        params: {
+          end,
+          start,
+          email
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    await testMethodOfGettingCsv(procPromise, aggrPromise, res)
+  })
+
   it('it should not be successfully auth by the getLedgersCsv method', async function () {
     this.timeout(60000)
 

--- a/test/4-queue-base.spec.js
+++ b/test/4-queue-base.spec.js
@@ -42,12 +42,13 @@ const auth = {
   apiKey: 'fake',
   apiSecret: 'fake'
 }
+const mockDataAmount = 10000
 
 describe('Queue', () => {
   before(async function () {
     this.timeout(20000)
 
-    mockRESTv2Srv = createMockRESTv2SrvWithDate(start, end, 10000)
+    mockRESTv2Srv = createMockRESTv2SrvWithDate(start, end, mockDataAmount)
 
     await rmAllFiles(tempDirPath)
     await rmDB(dbDirPath)
@@ -825,6 +826,8 @@ describe('Queue', () => {
     const procPromise = queueToPromise(processorQueue)
     const aggrPromise = queueToPromise(aggregatorQueue)
 
+    const _start = end - ((end - start) / (mockDataAmount / 2000))
+
     const res = await agent
       .post(`${basePath}/json-rpc`)
       .type('json')
@@ -833,7 +836,7 @@ describe('Queue', () => {
         method: 'getWeightedAveragesReportCsv',
         params: {
           end,
-          start,
+          start: _start,
           email
         },
         id: 5

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -27,6 +27,9 @@ const generateCsv = require('../generate-csv')
 const CsvJobData = require('../generate-csv/csv.job.data')
 const Interrupter = require('../interrupter')
 const AbstractWSEventEmitter = require('../abstract.ws.event.emitter')
+const {
+  weightedAveragesReportCsvWriter
+} = require('../generate-csv/csv-writer')
 
 module.exports = ({
   rService,
@@ -180,5 +183,15 @@ module.exports = ({
       .to(Interrupter)
     bind(TYPES.AbstractWSEventEmitter)
       .to(AbstractWSEventEmitter)
+    bind(TYPES.WeightedAveragesReportCsvWriter)
+      .toConstantValue(
+        bindDepsToFn(
+          weightedAveragesReportCsvWriter,
+          [
+            TYPES.RService,
+            TYPES.GetDataFromApi
+          ]
+        )
+      )
   })
 }

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -30,6 +30,7 @@ const AbstractWSEventEmitter = require('../abstract.ws.event.emitter')
 const {
   weightedAveragesReportCsvWriter
 } = require('../generate-csv/csv-writer')
+const WeightedAveragesReport = require('../weighted.averages.report')
 
 module.exports = ({
   rService,
@@ -48,7 +49,8 @@ module.exports = ({
       ['_grcBfxReq', TYPES.GrcBfxReq],
       ['_prepareApiResponse', TYPES.PrepareApiResponse],
       ['_generateCsv', TYPES.GenerateCsv],
-      ['_hasGrcService', TYPES.HasGrcService]
+      ['_hasGrcService', TYPES.HasGrcService],
+      ['_weightedAveragesReport', TYPES.WeightedAveragesReport]
     ])
     bind(TYPES.RServiceDepsSchemaAliase)
       .toDynamicValue((ctx) => {
@@ -193,5 +195,7 @@ module.exports = ({
           ]
         )
       )
+    bind(TYPES.WeightedAveragesReport)
+      .to(WeightedAveragesReport)
   })
 }

--- a/workers/loc.api/di/types.js
+++ b/workers/loc.api/di/types.js
@@ -31,5 +31,6 @@ module.exports = {
   CsvJobData: Symbol.for('CsvJobData'),
   Interrupter: Symbol.for('Interrupter'),
   AbstractWSEventEmitter: Symbol.for('AbstractWSEventEmitter'),
-  GetDataFromApi: Symbol.for('GetDataFromApi')
+  GetDataFromApi: Symbol.for('GetDataFromApi'),
+  WeightedAveragesReportCsvWriter: Symbol.for('WeightedAveragesReportCsvWriter')
 }

--- a/workers/loc.api/di/types.js
+++ b/workers/loc.api/di/types.js
@@ -32,5 +32,6 @@ module.exports = {
   Interrupter: Symbol.for('Interrupter'),
   AbstractWSEventEmitter: Symbol.for('AbstractWSEventEmitter'),
   GetDataFromApi: Symbol.for('GetDataFromApi'),
+  WeightedAveragesReport: Symbol.for('WeightedAveragesReport'),
   WeightedAveragesReportCsvWriter: Symbol.for('WeightedAveragesReportCsvWriter')
 }

--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -114,14 +114,6 @@ class MinLimitParamError extends UnprocessableEntityError {
   }
 }
 
-class MaxWeightedAveragesReportTradesNumError extends UnprocessableEntityError {
-  constructor (message = 'ERR_REDUCE_TRADES_NUMBER_IS_NEEDED_FOR_WEIGHTED_AVERAGES_REPORT') {
-    super(message)
-
-    this.statusMessage = 'To show the weighted averages report, it is required to reduce the number of trades so that it is no more than 2k'
-  }
-}
-
 class QueueJobAddingError extends ConflictError {
   constructor (message = 'ERR_HAS_JOB_IN_QUEUE') {
     super(message)
@@ -193,6 +185,5 @@ module.exports = {
   ArgsParamsFilterError,
   LedgerPaymentFilteringParamsError,
   GrcSlackAvailabilityError,
-  ImplementationError,
-  MaxWeightedAveragesReportTradesNumError
+  ImplementationError
 }

--- a/workers/loc.api/errors/index.js
+++ b/workers/loc.api/errors/index.js
@@ -114,6 +114,14 @@ class MinLimitParamError extends UnprocessableEntityError {
   }
 }
 
+class MaxWeightedAveragesReportTradesNumError extends UnprocessableEntityError {
+  constructor (message = 'ERR_REDUCE_TRADES_NUMBER_IS_NEEDED_FOR_WEIGHTED_AVERAGES_REPORT') {
+    super(message)
+
+    this.statusMessage = 'To show the weighted averages report, it is required to reduce the number of trades so that it is no more than 2k'
+  }
+}
+
 class QueueJobAddingError extends ConflictError {
   constructor (message = 'ERR_HAS_JOB_IN_QUEUE') {
     super(message)
@@ -185,5 +193,6 @@ module.exports = {
   ArgsParamsFilterError,
   LedgerPaymentFilteringParamsError,
   GrcSlackAvailabilityError,
-  ImplementationError
+  ImplementationError,
+  MaxWeightedAveragesReportTradesNumError
 }

--- a/workers/loc.api/generate-csv/csv-writer/index.js
+++ b/workers/loc.api/generate-csv/csv-writer/index.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const weightedAveragesReportCsvWriter = require(
+  './weighted-averages-report-csv-writer'
+)
+
+module.exports = {
+  weightedAveragesReportCsvWriter
+}

--- a/workers/loc.api/generate-csv/csv-writer/weighted-averages-report-csv-writer.js
+++ b/workers/loc.api/generate-csv/csv-writer/weighted-averages-report-csv-writer.js
@@ -53,7 +53,7 @@ module.exports = (
   pipeline(headerStringifier, wStream, nope)
   pipeline(resStringifier, wStream, nope)
 
-  const res = await getDataFromApi({
+  const { res } = await getDataFromApi({
     getData: rService[name].bind(rService),
     args,
     callerName: 'CSV_WRITER'

--- a/workers/loc.api/generate-csv/csv-writer/weighted-averages-report-csv-writer.js
+++ b/workers/loc.api/generate-csv/csv-writer/weighted-averages-report-csv-writer.js
@@ -1,0 +1,77 @@
+'use strict'
+
+const { pipeline } = require('stream')
+const { stringify } = require('csv')
+
+const {
+  write
+} = require('../../queue/write-data-to-stream/helpers')
+
+const nope = () => {}
+
+module.exports = (
+  rService,
+  getDataFromApi
+) => async (
+  wStream,
+  jobData
+) => {
+  const queue = rService.ctx.lokue_aggregator.q
+  const {
+    args,
+    columnsCsv,
+    formatSettings,
+    name
+  } = jobData ?? {}
+  const { params } = args ?? {}
+
+  queue.emit('progress', 0)
+
+  if (typeof jobData === 'string') {
+    const stringifier = stringify(
+      { columns: ['mess'] }
+    )
+
+    pipeline(stringifier, wStream, nope)
+    write([{ mess: jobData }], stringifier)
+    queue.emit('progress', 100)
+    stringifier.end()
+
+    return
+  }
+
+  wStream.setMaxListeners(50)
+
+  const headerStringifier = stringify(
+    { columns: ['empty', 'buy', 'empty', 'sell', 'empty', 'cumulative', 'empty'] }
+  )
+  const resStringifier = stringify({
+    header: true,
+    columns: columnsCsv
+  })
+
+  pipeline(headerStringifier, wStream, nope)
+  pipeline(resStringifier, wStream, nope)
+
+  const res = await getDataFromApi({
+    getData: rService[name].bind(rService),
+    args,
+    callerName: 'CSV_WRITER'
+  })
+
+  write(
+    [{ empty: '', buy: 'Buy', sell: 'Sell', cumulative: 'Cumulative' }],
+    headerStringifier
+  )
+  write(
+    res,
+    resStringifier,
+    formatSettings,
+    params
+  )
+
+  queue.emit('progress', 100)
+
+  headerStringifier.end()
+  resStringifier.end()
+}

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -15,11 +15,16 @@ const {
 } = require('../errors')
 
 const depsTypes = (TYPES) => [
-  TYPES.RService
+  TYPES.RService,
+  TYPES.WeightedAveragesReportCsvWriter
 ]
 class CsvJobData {
-  constructor (rService) {
+  constructor (
+    rService,
+    weightedAveragesReportCsvWriter
+  ) {
     this.rService = rService
+    this.weightedAveragesReportCsvWriter = weightedAveragesReportCsvWriter
   }
 
   async getTradesCsvJobData (
@@ -1026,6 +1031,48 @@ class CsvJobData {
       args,
       jobsData
     }
+  }
+
+  async getWeightedAveragesReportCsvJobData (
+    args,
+    uId,
+    uInfo
+  ) {
+    checkParams(args, 'paramsSchemaForWeightedAveragesReportApiCsv')
+
+    const {
+      userId,
+      userInfo
+    } = await checkJobAndGetUserData(
+      this.rService,
+      uId,
+      uInfo
+    )
+
+    const csvArgs = getCsvArgs(args)
+
+    const jobData = {
+      userInfo,
+      userId,
+      name: 'getWeightedAveragesReport',
+      fileNamesMap: [['getWeightedAveragesReport', 'weighted-averages-report']],
+      args: csvArgs,
+      columnsCsv: {
+        symbol: 'PAIR',
+        buyingWeightedPrice: 'WEIGHTED PRICE',
+        buyingAmount: 'AMOUNT',
+        sellingWeightedPrice: 'WEIGHTED PRICE',
+        sellingAmount: 'AMOUNT',
+        cumulativeWeightedPrice: 'WEIGHTED PRICE',
+        cumulativeAmount: 'AMOUNT'
+      },
+      formatSettings: {
+        symbol: 'symbol'
+      },
+      csvCustomWriter: this.weightedAveragesReportCsvWriter
+    }
+
+    return jobData
   }
 }
 

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { cloneDeep } = require('lodash')
+
 const _publicTradesSymbol = {
   type: ['string', 'array'],
   if: {
@@ -125,6 +127,21 @@ const paramsSchemaForCandlesApi = {
     },
     sort: {
       type: 'integer'
+    }
+  }
+}
+
+const paramsSchemaForWeightedAveragesReportApi = {
+  type: 'object',
+  properties: {
+    start: {
+      type: 'integer'
+    },
+    end: {
+      type: 'integer'
+    },
+    symbol: {
+      type: ['string', 'array']
     }
   }
 }
@@ -321,6 +338,16 @@ const paramsSchemaForOrderTradesCsv = {
   }
 }
 
+const paramsSchemaForWeightedAveragesReportApiCsv = {
+  type: 'object',
+  properties: {
+    ...cloneDeep(paramsSchemaForWeightedAveragesReportApi.properties),
+    timezone,
+    dateFormat,
+    language
+  }
+}
+
 module.exports = {
   paramsSchemaForApi,
   paramsSchemaForCsv,
@@ -339,5 +366,7 @@ module.exports = {
   paramsSchemaForStatusMessagesApi,
   paramsSchemaForStatusMessagesCsv,
   paramsSchemaForCandlesApi,
-  paramsSchemaForCandlesCsv
+  paramsSchemaForCandlesCsv,
+  paramsSchemaForWeightedAveragesReportApi,
+  paramsSchemaForWeightedAveragesReportApiCsv
 }

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -593,6 +593,15 @@ class ReportService extends Api {
     }, 'getChangeLogs', args, cb)
   }
 
+  getWeightedAveragesReport (space, args, cb) {
+    return this._responder(async () => {
+      checkParams(args, 'paramsSchemaForWeightedAveragesReportApi')
+
+      return this._weightedAveragesReport
+        .getWeightedAveragesReport(args)
+    }, 'getWeightedAveragesReport', args, cb)
+  }
+
   getMultipleCsv (space, args, cb) {
     return this._responder(() => {
       return this._generateCsv(

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -799,6 +799,15 @@ class ReportService extends Api {
       )
     }, 'getChangeLogsCsv', args, cb)
   }
+
+  getWeightedAveragesReportCsv (space, args, cb) {
+    return this._responder(() => {
+      return this._generateCsv(
+        'getWeightedAveragesReportCsvJobData',
+        args
+      )
+    }, 'getWeightedAveragesReportCsv', args, cb)
+  }
 }
 
 module.exports = ReportService

--- a/workers/loc.api/weighted.averages.report/index.js
+++ b/workers/loc.api/weighted.averages.report/index.js
@@ -1,0 +1,168 @@
+'use strict'
+
+const { decorateInjectable } = require('../di/utils')
+
+const depsTypes = (TYPES) => [
+  TYPES.RService
+]
+class WeightedAveragesReport {
+  constructor (
+    rService
+  ) {
+    this.rService = rService
+  }
+
+  async getWeightedAveragesReport (args = {}) {
+    const {
+      auth = {},
+      params = {}
+    } = args ?? {}
+
+    const {
+      start = 0,
+      end = Date.now(),
+      symbol: _symbol = []
+    } = params ?? {}
+    const symbolArr = Array.isArray(_symbol)
+      ? _symbol
+      : [_symbol]
+    const symbol = symbolArr.filter((s) => (
+      s && typeof s === 'string'
+    ))
+
+    const trades = await this._getTrades({
+      auth,
+      start,
+      end,
+      symbol
+    })
+    const calcedTrades = this._calcTrades(trades)
+
+    return calcedTrades
+  }
+
+  async _getTrades (args) {
+    const {
+      auth = {},
+      start = 0,
+      end = Date.now(),
+      symbol = []
+    } = args ?? {}
+
+    const symbFilter = (
+      Array.isArray(symbol) &&
+      symbol.length !== 0
+    )
+      ? { $in: { symbol } }
+      : {}
+
+    // TODO:
+    return []
+  }
+
+  _calcTrades (trades = []) {
+    const symbResMap = new Map()
+
+    for (const trade of trades) {
+      const {
+        symbol,
+        execAmount,
+        execPrice
+      } = trade ?? {}
+
+      if (
+        !symbol ||
+        typeof symbol !== 'string' ||
+        !Number.isFinite(execAmount) ||
+        execAmount === 0 ||
+        !Number.isFinite(execPrice) ||
+        execPrice === 0
+      ) {
+        continue
+      }
+
+      const isBuying = execAmount > 0
+      const spent = execAmount * execPrice
+
+      const existedSymbRes = symbResMap.get(symbol)
+      const {
+        sumSpent: _sumSpent = 0,
+        sumAmount: _sumAmount = 0,
+        sumBuyingSpent: _sumBuyingSpent = 0,
+        sumBuyingAmount: _sumBuyingAmount = 0,
+        sumSellingSpent: _sumSellingSpent = 0,
+        sumSellingAmount: _sumSellingAmount = 0
+      } = existedSymbRes ?? {}
+
+      const sumSpent = Number.isFinite(spent)
+        ? _sumSpent + spent
+        : _sumSpent
+      const sumAmount = _sumAmount + execAmount
+      const sumBuyingSpent = (
+        isBuying &&
+        Number.isFinite(spent)
+      )
+        ? _sumBuyingSpent + spent
+        : _sumBuyingSpent
+      const sumBuyingAmount = isBuying
+        ? _sumBuyingAmount + execAmount
+        : _sumBuyingAmount
+      const sumSellingSpent = (
+        !isBuying &&
+        Number.isFinite(spent)
+      )
+        ? _sumSellingSpent + spent
+        : _sumSellingSpent
+      const sumSellingAmount = !isBuying
+        ? _sumSellingAmount + execAmount
+        : _sumSellingAmount
+
+      symbResMap.set(symbol, {
+        sumSpent,
+        sumAmount,
+        sumBuyingSpent,
+        sumBuyingAmount,
+        sumSellingSpent,
+        sumSellingAmount,
+
+        buyingWeightedPrice: sumBuyingAmount === 0
+          ? 0
+          : sumBuyingSpent / sumBuyingAmount,
+        buyingAmount: sumBuyingAmount,
+        sellingWeightedPrice: sumSellingAmount === 0
+          ? 0
+          : sumSellingSpent / sumSellingAmount,
+        sellingAmount: sumSellingAmount,
+        cumulativeWeightedPrice: sumAmount === 0
+          ? 0
+          : sumSpent / sumAmount,
+        cumulativeAmount: sumAmount
+      })
+    }
+
+    return [...symbResMap].map(([symbol, val]) => {
+      const {
+        buyingWeightedPrice = 0,
+        buyingAmount = 0,
+        sellingWeightedPrice = 0,
+        sellingAmount = 0,
+        cumulativeWeightedPrice = 0,
+        cumulativeAmount = 0
+      } = val ?? {}
+
+      return {
+        symbol,
+        buyingWeightedPrice,
+        buyingAmount,
+        sellingWeightedPrice,
+        sellingAmount,
+        cumulativeWeightedPrice,
+        cumulativeAmount
+      }
+    })
+  }
+}
+
+decorateInjectable(WeightedAveragesReport, depsTypes)
+
+module.exports = WeightedAveragesReport


### PR DESCRIPTION
This PR adds the `Weighted Averages` report to the web version. The main part of logic moves from the `bfx-reports-framework` and the behavior is the same as in the previous PR https://github.com/bitfinexcom/bfx-reports-framework/pull/246

---

**Breaking changes**

Response example in case trades number is more than 2k (if trades number is less than 2k -> `nextPage: false`):
```jsonc
{
  "jsonrpc": "2.0",
  "result": {
    "nextPage": 1542191602000, // trades number is less than 2k -> `nextPage: false`
    "res": [
      {
        "symbol": "tUSTUSD",
        "buyingWeightedPrice": 1.12345,
        "buyingAmount": 12345,
        "sellingWeightedPrice": 1.12345,
        "sellingAmount": -12345,
        "cumulativeWeightedPrice": 1.12345,
        "cumulativeAmount": 12345
      }
    ]
  },
  "id": null
}
```

---

Basic changes:

- Adds `getWeightedAveragesReport` method to the main service
- Adds `getWeightedAveragesReportCsv` method to the main service
- Adds corresponding test coverage