### PR TITLE
Add temporarily_unavailable bfx error handler

### DIFF
--- a/workers/loc.api/helpers/api-errors-testers.js
+++ b/workers/loc.api/helpers/api-errors-testers.js
@@ -56,6 +56,10 @@ const isEProtoError = (err) => {
   return /EPROTO/.test(err.toString())
 }
 
+const isTempUnavailableError = (err) => {
+  return /temporarily_unavailable/.test(err.toString())
+}
+
 const isENetError = (err) => (
   isENetUnreachError(err) ||
   isEConnResetError(err) ||
@@ -65,7 +69,8 @@ const isENetError = (err) => (
   isENotFoundError(err) ||
   isESocketTimeoutError(err) ||
   isEHostUnreachError(err) ||
-  isEProtoError(err)
+  isEProtoError(err) ||
+  isTempUnavailableError(err)
 )
 
 module.exports = {
@@ -83,5 +88,6 @@ module.exports = {
   isESocketTimeoutError,
   isEHostUnreachError,
   isEProtoError,
+  isTempUnavailableError,
   isENetError
 }


### PR DESCRIPTION
This PR adds the `temporarily_unavailable` BFX error handler, it's related to issues when the main platform is under maintenance, we should cover this `bfx_api_v2` error, check the screenshot
Instead showing an error modal dialog under the electron app would show the network issue message. And also it adds some retries for fetching data as it was done earlier for the common `isENetError` checker

![Screenshot from 2023-03-06 12-32-06](https://user-images.githubusercontent.com/16489235/230874940-3564a562-a393-40b2-8409-df94c6e519bf.png)

