### PR TITLE
Increase getAccountSummary request timeout

### DIFF
--- a/workers/loc.api/helpers/get-rest.js
+++ b/workers/loc.api/helpers/get-rest.js
@@ -130,7 +130,7 @@ const _getRestProxy = (rest) => {
 module.exports = (conf) => {
   bfxInstance = _bfxFactory(conf)
 
-  return (auth) => {
+  return (auth, opts) => {
     if (
       !auth ||
       typeof auth !== 'object'
@@ -143,6 +143,9 @@ module.exports = (conf) => {
       apiSecret = '',
       authToken: _authToken = ''
     } = auth
+    const {
+      timeout = 20000
+    } = opts ?? {}
 
     /*
      * It uses dynamic getter to fetch refreshed auth token
@@ -155,8 +158,12 @@ module.exports = (conf) => {
     const _auth = authToken
       ? { authToken }
       : { apiKey, apiSecret }
+    const restOpts = {
+      timeout,
+      ..._auth
+    }
 
-    const rest = bfxInstance.rest(2, _auth)
+    const rest = bfxInstance.rest(2, restOpts)
     const proxy = _getRestProxy(rest)
 
     return proxy

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -560,7 +560,7 @@ class ReportService extends Api {
   getAccountSummary (space, args, cb) {
     return this._responder(async () => {
       const { auth } = { ...args }
-      const rest = this._getREST(auth)
+      const rest = this._getREST(auth, { timeout: 30000 })
 
       const res = await rest.accountSummary()
 


### PR DESCRIPTION
This PR increases `getAccountSummary` request timeout to `30s`, the rest requests will use `20s` timeout for the `bfx-api-node-rest` lib