### PR TITLE
Add 3 retries when catching rate limit error

### DIFF
--- a/workers/loc.api/helpers/get-data-from-api.js
+++ b/workers/loc.api/helpers/get-data-from-api.js
@@ -109,7 +109,7 @@ module.exports = (
       if (isRateLimitError(err)) {
         countRateLimitError += 1
 
-        if (countRateLimitError > 2) {
+        if (countRateLimitError > 3) {
           throw err
         }
         if (_isInterrupted(_interrupter)) {


### PR DESCRIPTION
This PR adds `3` retries instead of 2 when catching `Rate Limit` error to help users to go through sync in the electron app