### PR TITLE
Add currency movement info endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bfx-facs-lokue": "git+https://github.com:bitfinexcom/bfx-facs-lokue.git",
     "bfx-svc-boot-js": "https://github.com/bitfinexcom/bfx-svc-boot-js.git",
     "bfx-wrk-api": "git+https://github.com/bitfinexcom/bfx-wrk-api.git",
-    "bitfinex-api-node": "5.0.2",
+    "bitfinex-api-node": "6.0.0",
     "colors": "1.4.0",
     "csv": "5.5.3",
     "inversify": "6.0.1",

--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -1510,6 +1510,50 @@ describe('API', () => {
     assert.propertyVal(res.body, 'id', 5)
   })
 
+  it('it should be successfully performed by the getMovementInfo method', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getMovementInfo',
+        params: {
+          id: 12345
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+
+    assert.containsAllKeys(res.body.result, [
+      'id',
+      'currency',
+      'currencyName',
+      'remark',
+      'mtsStarted',
+      'mtsUpdated',
+      'status',
+      'amount',
+      'fees',
+      'destinationAddress',
+      'memo',
+      'transactionId',
+      'note',
+      'bankFees',
+      'bankRouterId',
+      'externalBankMovId',
+      'externalBankMovStatus',
+      'externalBankMovDescription',
+      'externalBankAccInfo'
+    ])
+  })
+
   it('it should be successfully performed by the getAccountSummary method', async function () {
     this.timeout(5000)
 

--- a/test/helpers/helpers.mock-rest-v2.js
+++ b/test/helpers/helpers.mock-rest-v2.js
@@ -157,6 +157,12 @@ const setDataTo = (
       dataItem[6] = _date
       break
 
+    case 'movement_info':
+      dataItem[0] = id
+      dataItem[5] = _date
+      dataItem[6] = _date
+      break
+
     case 'f_offer_hist':
       dataItem[0] = id
       dataItem[2] = _date
@@ -212,7 +218,8 @@ const getMockDataOpts = () => ({
   account_summary: null,
   get_settings: null,
   set_settings: null,
-  generate_token: null
+  generate_token: null,
+  movement_info: null
 })
 
 const createMockRESTv2SrvWithDate = (

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -373,6 +373,43 @@ module.exports = new Map([
     ]]
   ],
   [
+    'movement_info',
+    [
+      12345,
+      'BTC',
+      'BITCOIN',
+      null,
+      'REMARK',
+      _ms,
+      _ms,
+      null,
+      null,
+      'PENDING REVIEW',
+      null,
+      null,
+      -0.009999,
+      -0.000001,
+      null,
+      null,
+      '0x047633e8e976dc13a81ac3e45564f6b83d10aeb9',
+      'MEMO',
+      null,
+      null,
+      '0x754687b3cbee7cdc4b29107e325455c682dfc320ca0c4233c313263a27282760',
+      'look at this note',
+      null,
+      null,
+      -0.123,
+      12345,
+      null,
+      null,
+      'externalBankMovId',
+      'externalBankMovStatus',
+      'externalBankMovDescription',
+      'externalBankAccInfo'
+    ]
+  ],
+  [
     'f_offer_hist',
     [[
       12345,

--- a/workers/loc.api/helpers/prepare-response.js
+++ b/workers/loc.api/helpers/prepare-response.js
@@ -17,7 +17,6 @@ const {
   LedgerPaymentFilteringParamsError
 } = require('../errors')
 
-// TODO:
 const _paramsMap = {
   default: {
     symbol: 'symbol',
@@ -25,6 +24,7 @@ const _paramsMap = {
     end: 'end',
     limit: 'limit'
   },
+
   candles: {
     timeframe: 'timeframe',
     symbol: 'symbol',
@@ -40,53 +40,58 @@ const _paramsMap = {
     limit: 'limit',
     symbol: 'filters.ccy',
     category: 'filters.category'
+  },
+  statusMessages: {
+    type: 'type',
+    symbol: 'keys'
+  },
+  positionsAudit: {
+    start: 'start',
+    end: 'end',
+    limit: 'limit',
+    id: 'id'
+  },
+  orderTrades: {
+    start: 'start',
+    end: 'end',
+    limit: 'limit',
+    id: 'orderId'
+  },
+  tickersHistory: {
+    symbol: 'symbols',
+    start: 'start',
+    end: 'end',
+    limit: 'limit'
+  },
+  payInvoiceList: {
+    start: 'start',
+    end: 'end',
+    limit: 'limit',
+    id: 'id'
+  },
+  trades: {
+    symbol: 'symbol',
+    start: 'start',
+    end: 'end',
+    limit: 'limit',
+    sort: 'sort'
+  },
+  accountTrades: {
+    symbol: 'symbol',
+    start: 'start',
+    end: 'end',
+    limit: 'limit',
+    sort: 'sort'
+  },
+  movements: {
+    symbol: 'ccy',
+    start: 'start',
+    end: 'end',
+    limit: 'limit',
+    address: 'address',
+    id: 'id'
   }
 }
-// const _paramsOrderMap = {
-//   positionsSnapshot: [
-//     'start',
-//     'end',
-//     'limit'
-//   ],
-//   statusMessages: [
-//     'type',
-//     'symbol'
-//   ],
-//   positionsHistory: [
-//     'start',
-//     'end',
-//     'limit'
-//   ],
-//   positionsAudit: [
-//     'id',
-//     'start',
-//     'end',
-//     'limit'
-//   ],
-//   orderTrades: [
-//     'symbol',
-//     'start',
-//     'end',
-//     'limit',
-//     'id'
-//   ],
-//   logins: [
-//     'start',
-//     'end',
-//     'limit'
-//   ],
-//   changeLogs: [
-//     'start',
-//     'end',
-//     'limit'
-//   ],
-//   default: [
-//     'symbol',
-//     'start',
-//     'end',
-//     'limit'
-//   ]
-// }
 
 const _paramsSchemasMap = {
   payInvoiceList: 'paramsSchemaForPayInvoiceList',

--- a/workers/loc.api/helpers/prepare-response/helpers/get-bfx-api-method-name.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/get-bfx-api-method-name.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const BFX_API_METHOD_NAME_MAP = {
+  trades: 'accountTrades',
+  publicTrades: 'trades',
+  orders: 'orderHistory'
+}
+
+module.exports = (
+  methodName,
+  map = BFX_API_METHOD_NAME_MAP
+) => {
+  return map?.[methodName] ?? methodName
+}

--- a/workers/loc.api/helpers/prepare-response/helpers/get-params-map.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/get-params-map.js
@@ -66,10 +66,10 @@ const PARAMS_MAP = {
 }
 
 module.exports = (
-  methodName,
+  apiMethodName,
   map = PARAMS_MAP
 ) => {
-  const _methodName = getBfxApiMethodName(methodName)
+  const bfxApiMethodName = getBfxApiMethodName(apiMethodName)
 
-  return map?.[_methodName] ?? map.default
+  return map?.[bfxApiMethodName] ?? map.default
 }

--- a/workers/loc.api/helpers/prepare-response/helpers/get-params-map.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/get-params-map.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const getBfxApiMethodName = require('./get-bfx-api-method-name')
+
 const MAIN_PARAMS_MAP = {
   start: 'start',
   end: 'end',
@@ -64,8 +66,10 @@ const PARAMS_MAP = {
 }
 
 module.exports = (
-  method,
+  methodName,
   map = PARAMS_MAP
 ) => {
-  return map?.[method] ?? map.default
+  const _methodName = getBfxApiMethodName(methodName)
+
+  return map?.[_methodName] ?? map.default
 }

--- a/workers/loc.api/helpers/prepare-response/helpers/get-params-map.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/get-params-map.js
@@ -1,0 +1,71 @@
+'use strict'
+
+const MAIN_PARAMS_MAP = {
+  start: 'start',
+  end: 'end',
+  limit: 'limit'
+}
+const DEFAULT_PARAMS_MAP = {
+  ...MAIN_PARAMS_MAP,
+  symbol: 'symbol'
+}
+
+const PARAMS_MAP = {
+  default: DEFAULT_PARAMS_MAP,
+
+  candles: {
+    timeframe: 'timeframe',
+    symbol: 'symbol',
+    section: 'section',
+    sort: 'query.sort',
+    start: 'query.start',
+    end: 'query.end',
+    limit: 'query.limit'
+  },
+  ledgers: {
+    ...MAIN_PARAMS_MAP,
+    symbol: 'filters.ccy',
+    category: 'filters.category'
+  },
+  statusMessages: {
+    type: 'type',
+    symbol: 'keys'
+  },
+  positionsAudit: {
+    ...MAIN_PARAMS_MAP,
+    id: 'id'
+  },
+  orderTrades: {
+    ...MAIN_PARAMS_MAP,
+    id: 'orderId'
+  },
+  tickersHistory: {
+    ...MAIN_PARAMS_MAP,
+    symbol: 'symbols'
+  },
+  payInvoiceList: {
+    ...MAIN_PARAMS_MAP,
+    id: 'id'
+  },
+  trades: {
+    ...DEFAULT_PARAMS_MAP,
+    sort: 'sort'
+  },
+  accountTrades: {
+    ...DEFAULT_PARAMS_MAP,
+    sort: 'sort'
+  },
+  movements: {
+    ...MAIN_PARAMS_MAP,
+    symbol: 'ccy',
+    address: 'address',
+    id: 'id'
+  }
+}
+
+module.exports = (
+  method,
+  map = PARAMS_MAP
+) => {
+  return map?.[method] ?? map.default
+}

--- a/workers/loc.api/helpers/prepare-response/helpers/get-params-schema-name.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/get-params-schema-name.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const PARAMS_SCHEMAS_MAP = {
+  default: 'paramsSchemaForApi',
+
+  payInvoiceList: 'paramsSchemaForPayInvoiceList',
+  statusMessages: 'paramsSchemaForStatusMessagesApi',
+  publicTrades: 'paramsSchemaForPublicTrades',
+  positionsAudit: 'paramsSchemaForPositionsAudit',
+  orderTrades: 'paramsSchemaForOrderTradesApi',
+  candles: 'paramsSchemaForCandlesApi'
+}
+
+module.exports = (
+  method,
+  map = PARAMS_SCHEMAS_MAP
+) => {
+  return map?.[method] ?? map.default
+}

--- a/workers/loc.api/helpers/prepare-response/helpers/get-params.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/get-params.js
@@ -1,0 +1,59 @@
+'use strict'
+
+const { cloneDeep } = require('lodash')
+
+const { getDateNotMoreNow } = require('../../date-param.helpers')
+const { getMethodLimit } = require('../../limit-param.helpers')
+
+const getParamsMap = require('./get-params-map')
+const getSymbolParams = require('./get-symbol-params')
+
+module.exports = (
+  { args, apiMethodName, symbPropName },
+  opts = {}
+) => {
+  if (
+    !args.params ||
+    typeof args.params !== 'object'
+  ) {
+    return {
+      queryParams: {},
+      allParams: {}
+    }
+  }
+
+  const { params } = args ?? {}
+  const { isInnerMax, isNotMoreThanInnerMax } = opts ?? {}
+  const limit = isInnerMax
+    ? { isInnerMax }
+    : { limit: params.limit, isNotMoreThanInnerMax }
+  const allParams = {
+    ...cloneDeep(params),
+    ...getSymbolParams({ apiMethodName, params, symbPropName }),
+    end: getDateNotMoreNow(params.end),
+    limit: getMethodLimit(limit, apiMethodName)
+  }
+  const paramsMap = getParamsMap(apiMethodName)
+  const queryParams = Object.entries(paramsMap)
+    .reduce((accum, [inParamName, queryParamNamesStr]) => {
+      const queryParamNamesArr = queryParamNamesStr.split('.')
+      const value = allParams[inParamName]
+
+      queryParamNamesArr.reduce((innerAccum, propName, i, arr) => {
+        const isLast = arr.length === (i + 1)
+
+        innerAccum[propName] = isLast
+          ? value
+          : innerAccum[propName] ?? {}
+
+        return innerAccum[propName]
+      }, accum)
+
+      return accum
+    }, {})
+
+  return {
+    queryParams,
+    allParams
+  }
+}

--- a/workers/loc.api/helpers/prepare-response/helpers/get-symbol-params.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/get-symbol-params.js
@@ -1,0 +1,107 @@
+'use strict'
+
+const { isEmpty } = require('lodash')
+
+const {
+  LedgerPaymentFilteringParamsError
+} = require('../../../errors')
+
+module.exports = ({
+  apiMethodName,
+  params,
+  symbPropName
+}) => {
+  const {
+    isMarginFundingPayment,
+    isAffiliateRebate,
+    isStakingPayments,
+    symbol,
+    category
+  } = params ?? {}
+
+  if (apiMethodName === 'payInvoiceList') {
+    return { symbol: null }
+  }
+  if (
+    apiMethodName === 'candles' ||
+    apiMethodName === 'publicTrades'
+  ) {
+    return {
+      symbol: Array.isArray(symbol)
+        ? symbol[0]
+        : symbol
+    }
+  }
+  if (apiMethodName === 'statusMessages') {
+    const _symbol = isEmpty(symbol)
+      ? 'ALL'
+      : symbol
+
+    return {
+      symbol: Array.isArray(_symbol)
+        ? _symbol
+        : [_symbol]
+    }
+  }
+  if (
+    apiMethodName === 'ledgers' &&
+    (
+      isMarginFundingPayment ||
+      isAffiliateRebate ||
+      isStakingPayments ||
+      category
+    )
+  ) {
+    if ([
+      isMarginFundingPayment,
+      isAffiliateRebate,
+      isStakingPayments,
+      category
+    ].filter(f => f).length > 1) {
+      throw new LedgerPaymentFilteringParamsError()
+    }
+
+    const symbArr = Array.isArray(symbol)
+      ? symbol
+      : [symbol]
+    const ccy = symbArr.length > 1
+      ? null
+      : symbArr[0]
+
+    if (category) {
+      const normCategory = typeof category === 'string'
+        ? Number.parseFloat(category)
+        : category
+
+      return { symbol: ccy, category: normCategory }
+    }
+    if (isAffiliateRebate) {
+      return { symbol: ccy, category: 241 }
+    }
+    if (isStakingPayments) {
+      return { symbol: ccy, category: 262 }
+    }
+
+    return { symbol: ccy, category: 28 }
+  }
+  if (
+    typeof symbPropName === 'string' &&
+    apiMethodName !== 'positionsHistory' &&
+    apiMethodName !== 'positionsAudit' &&
+    Array.isArray(symbol)
+  ) {
+    return {
+      symbol: symbol.length > 1
+        ? null
+        : symbol[0]
+    }
+  }
+  if (
+    !symbol &&
+    apiMethodName === 'fundingTrades'
+  ) {
+    return { symbol: null }
+  }
+
+  return { symbol }
+}

--- a/workers/loc.api/helpers/prepare-response/helpers/get-symbols-for-filtering.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/get-symbols-for-filtering.js
@@ -1,0 +1,35 @@
+'use strict'
+
+module.exports = ({
+  apiMethodName,
+  symbPropName,
+  args
+}) => {
+  if (
+    typeof symbPropName !== 'string' ||
+    !args?.params?.symbol ||
+    apiMethodName === 'candles' ||
+    apiMethodName === 'publicTrades'
+  ) {
+    return null
+  }
+
+  const symbol = args.params.symbol
+
+  if (
+    apiMethodName === 'positionsHistory' ||
+    apiMethodName === 'positionsAudit' ||
+    apiMethodName === 'payInvoiceList'
+  ) {
+    return Array.isArray(symbol)
+      ? [...symbol]
+      : [symbol]
+  }
+
+  return (
+    Array.isArray(symbol) &&
+    symbol.length > 1
+  )
+    ? [...symbol]
+    : null
+}

--- a/workers/loc.api/helpers/prepare-response/helpers/index.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/index.js
@@ -7,6 +7,7 @@ const getBfxApiMethodName = require('./get-bfx-api-method-name')
 const getSymbolsForFiltering = require('./get-symbols-for-filtering')
 const getSymbolParams = require('./get-symbol-params')
 const getParams = require('./get-params')
+const isNotContainedSameMts = require('./is-not-contained-same-mts')
 
 module.exports = {
   getParamsMap,
@@ -15,5 +16,6 @@ module.exports = {
   getBfxApiMethodName,
   getSymbolsForFiltering,
   getSymbolParams,
-  getParams
+  getParams,
+  isNotContainedSameMts
 }

--- a/workers/loc.api/helpers/prepare-response/helpers/index.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/index.js
@@ -2,8 +2,10 @@
 
 const getParamsMap = require('./get-params-map')
 const getParamsSchemaName = require('./get-params-schema-name')
+const omitPrivateModelFields = require('./omit-private-model-fields')
 
 module.exports = {
   getParamsMap,
-  getParamsSchemaName
+  getParamsSchemaName,
+  omitPrivateModelFields
 }

--- a/workers/loc.api/helpers/prepare-response/helpers/index.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/index.js
@@ -4,10 +4,12 @@ const getParamsMap = require('./get-params-map')
 const getParamsSchemaName = require('./get-params-schema-name')
 const omitPrivateModelFields = require('./omit-private-model-fields')
 const getBfxApiMethodName = require('./get-bfx-api-method-name')
+const getSymbolsForFiltering = require('./get-symbols-for-filtering')
 
 module.exports = {
   getParamsMap,
   getParamsSchemaName,
   omitPrivateModelFields,
-  getBfxApiMethodName
+  getBfxApiMethodName,
+  getSymbolsForFiltering
 }

--- a/workers/loc.api/helpers/prepare-response/helpers/index.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/index.js
@@ -1,7 +1,9 @@
 'use strict'
 
 const getParamsMap = require('./get-params-map')
+const getParamsSchemaName = require('./get-params-schema-name')
 
 module.exports = {
-  getParamsMap
+  getParamsMap,
+  getParamsSchemaName
 }

--- a/workers/loc.api/helpers/prepare-response/helpers/index.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/index.js
@@ -3,9 +3,11 @@
 const getParamsMap = require('./get-params-map')
 const getParamsSchemaName = require('./get-params-schema-name')
 const omitPrivateModelFields = require('./omit-private-model-fields')
+const getBfxApiMethodName = require('./get-bfx-api-method-name')
 
 module.exports = {
   getParamsMap,
   getParamsSchemaName,
-  omitPrivateModelFields
+  omitPrivateModelFields,
+  getBfxApiMethodName
 }

--- a/workers/loc.api/helpers/prepare-response/helpers/index.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/index.js
@@ -5,11 +5,13 @@ const getParamsSchemaName = require('./get-params-schema-name')
 const omitPrivateModelFields = require('./omit-private-model-fields')
 const getBfxApiMethodName = require('./get-bfx-api-method-name')
 const getSymbolsForFiltering = require('./get-symbols-for-filtering')
+const getSymbolParams = require('./get-symbol-params')
 
 module.exports = {
   getParamsMap,
   getParamsSchemaName,
   omitPrivateModelFields,
   getBfxApiMethodName,
-  getSymbolsForFiltering
+  getSymbolsForFiltering,
+  getSymbolParams
 }

--- a/workers/loc.api/helpers/prepare-response/helpers/index.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/index.js
@@ -6,6 +6,7 @@ const omitPrivateModelFields = require('./omit-private-model-fields')
 const getBfxApiMethodName = require('./get-bfx-api-method-name')
 const getSymbolsForFiltering = require('./get-symbols-for-filtering')
 const getSymbolParams = require('./get-symbol-params')
+const getParams = require('./get-params')
 
 module.exports = {
   getParamsMap,
@@ -13,5 +14,6 @@ module.exports = {
   omitPrivateModelFields,
   getBfxApiMethodName,
   getSymbolsForFiltering,
-  getSymbolParams
+  getSymbolParams,
+  getParams
 }

--- a/workers/loc.api/helpers/prepare-response/helpers/index.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/index.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const getParamsMap = require('./get-params-map')
+
+module.exports = {
+  getParamsMap
+}

--- a/workers/loc.api/helpers/prepare-response/helpers/is-not-contained-same-mts.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/is-not-contained-same-mts.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const { getMethodLimit } = require('../../limit-param.helpers')
+
+module.exports = (args, opts) => {
+  const {
+    apiRes,
+    apiMethodName,
+    datePropName,
+    limit
+  } = args ?? {}
+  const {
+    isMax = true,
+    isInnerMax,
+    isNotMoreThanInnerMax
+  } = opts ?? {}
+
+  if (!Array.isArray(apiRes)) {
+    return false
+  }
+
+  const firstElem = apiRes[0] ?? {}
+  const mts = firstElem?.[datePropName]
+  const methodLimit = getMethodLimit(
+    { isMax, isInnerMax, isNotMoreThanInnerMax },
+    apiMethodName
+  )
+
+  return (
+    apiRes.length === 0 ||
+    methodLimit > limit ||
+    apiRes.some((item) => (
+      item?.[datePropName] !== mts
+    ))
+  )
+}

--- a/workers/loc.api/helpers/prepare-response/helpers/omit-private-model-fields.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/omit-private-model-fields.js
@@ -8,7 +8,8 @@ const OMITTING_FIELDS = [
   '_fields',
   '_boolFields',
   '_fieldKeys',
-  '_apiInterface'
+  '_apiInterface',
+  'emptyFill'
 ]
 
 const _omitFields = (obj) => {

--- a/workers/loc.api/helpers/prepare-response/helpers/omit-private-model-fields.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/omit-private-model-fields.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const { omit } = require('lodash')
+
+const OMITTING_FIELDS = [
+  '_events',
+  '_eventsCount',
+  '_fields',
+  '_boolFields',
+  '_fieldKeys',
+  '_apiInterface'
+]
+
+const _omitFields = (obj) => {
+  const newObj = omit(obj, OMITTING_FIELDS)
+  newObj._isDataFromApiV2 = true
+
+  return newObj
+}
+
+module.exports = (res) => {
+  if (
+    Array.isArray(res) &&
+    res.length > 0 &&
+    res.every((item) => (item && typeof item === 'object'))
+  ) {
+    return res.map((item) => _omitFields(item))
+  }
+  if (
+    res &&
+    typeof res === 'object' &&
+    Object.keys(res).length > 0
+  ) {
+    return _omitFields(res)
+  }
+
+  return res
+}

--- a/workers/loc.api/helpers/prepare-response/index.js
+++ b/workers/loc.api/helpers/prepare-response/index.js
@@ -17,32 +17,9 @@ const {
   LedgerPaymentFilteringParamsError
 } = require('../../errors')
 const {
-  getParamsMap
+  getParamsMap,
+  getParamsSchemaName
 } = require('./helpers')
-
-const _paramsSchemasMap = {
-  payInvoiceList: 'paramsSchemaForPayInvoiceList',
-  statusMessages: 'paramsSchemaForStatusMessagesApi',
-  publicTrades: 'paramsSchemaForPublicTrades',
-  positionsAudit: 'paramsSchemaForPositionsAudit',
-  orderTrades: 'paramsSchemaForOrderTradesApi',
-  candles: 'paramsSchemaForCandlesApi',
-  default: 'paramsSchemaForApi'
-}
-
-const _getSchemaNameByMethodName = (
-  method,
-  map = _paramsSchemasMap
-) => {
-  return (
-    map &&
-    typeof map === 'object' &&
-    map[method] &&
-    typeof map[method] === 'string'
-  )
-    ? map[method]
-    : map.default
-}
 
 const _getSymbols = (
   methodApi,
@@ -422,7 +399,7 @@ const prepareApiResponse = (
     parseFieldsFn,
     isNotMoreThanInnerMax: _isNotMoreThanInnerMax
   } = params ?? {}
-  const schemaName = _getSchemaNameByMethodName(methodApi)
+  const schemaName = getParamsSchemaName(methodApi)
 
   checkParams(reqArgs, schemaName, requireFields)
   const args = normalizeFilterParams(methodApi, reqArgs)

--- a/workers/loc.api/helpers/prepare-response/index.js
+++ b/workers/loc.api/helpers/prepare-response/index.js
@@ -2,8 +2,7 @@
 
 const {
   cloneDeep,
-  isEmpty,
-  omit
+  isEmpty
 } = require('lodash')
 
 const filterResponse = require('../filter-response')
@@ -18,7 +17,8 @@ const {
 } = require('../../errors')
 const {
   getParamsMap,
-  getParamsSchemaName
+  getParamsSchemaName,
+  omitPrivateModelFields
 } = require('./helpers')
 
 const _getSymbols = (
@@ -349,42 +349,6 @@ const prepareResponse = (
   return { res, nextPage }
 }
 
-const _omitPrivateModelFields = (res) => {
-  const omittingFields = [
-    '_events',
-    '_eventsCount',
-    '_fields',
-    '_boolFields',
-    '_fieldKeys',
-    '_apiInterface'
-  ]
-
-  if (
-    Array.isArray(res) &&
-    res.length > 0 &&
-    res.every((item) => (item && typeof item === 'object'))
-  ) {
-    return res.map((item) => {
-      return {
-        _isDataFromApiV2: true,
-        ...omit(item, omittingFields)
-      }
-    })
-  }
-  if (
-    res &&
-    typeof res === 'object' &&
-    Object.keys(res).length > 0
-  ) {
-    return {
-      _isDataFromApiV2: true,
-      ...omit(res, omittingFields)
-    }
-  }
-
-  return res
-}
-
 const prepareApiResponse = (
   getREST
 ) => async (
@@ -444,7 +408,7 @@ const prepareApiResponse = (
     notCheckNextPage,
     filter
   } = allParams
-  const omittedRes = _omitPrivateModelFields(apiRes)
+  const omittedRes = omitPrivateModelFields(apiRes)
   const res = typeof parseFieldsFn === 'function'
     ? parseFieldsFn(omittedRes)
     : omittedRes

--- a/workers/loc.api/helpers/prepare-response/index.js
+++ b/workers/loc.api/helpers/prepare-response/index.js
@@ -18,7 +18,8 @@ const {
 const {
   getParamsMap,
   getParamsSchemaName,
-  omitPrivateModelFields
+  omitPrivateModelFields,
+  getBfxApiMethodName
 } = require('./helpers')
 
 const _getSymbols = (
@@ -207,16 +208,6 @@ const _getParams = (
   }
 }
 
-const _parseMethodApi = name => {
-  const refactor = {
-    trades: 'accountTrades',
-    publicTrades: 'trades',
-    orders: 'orderHistory'
-  }
-
-  return refactor[name] || name
-}
-
 const _requestToApi = (
   getREST,
   method,
@@ -224,7 +215,7 @@ const _requestToApi = (
   auth
 ) => {
   const rest = getREST(auth)
-  const fn = rest[_parseMethodApi(method)].bind(rest)
+  const fn = rest[getBfxApiMethodName(method)].bind(rest)
 
   if (Array.isArray(params)) {
     return fn(...params)

--- a/workers/loc.api/helpers/prepare-response/index.js
+++ b/workers/loc.api/helpers/prepare-response/index.js
@@ -6,92 +6,19 @@ const {
   omit
 } = require('lodash')
 
-const filterResponse = require('./filter-response')
-const checkParams = require('./check-params')
-const checkFilterParams = require('./check-filter-params')
-const normalizeFilterParams = require('./normalize-filter-params')
-const { getMethodLimit } = require('./limit-param.helpers')
-const { getDateNotMoreNow } = require('./date-param.helpers')
+const filterResponse = require('../filter-response')
+const checkParams = require('../check-params')
+const checkFilterParams = require('../check-filter-params')
+const normalizeFilterParams = require('../normalize-filter-params')
+const { getMethodLimit } = require('../limit-param.helpers')
+const { getDateNotMoreNow } = require('../date-param.helpers')
 const {
   MinLimitParamError,
   LedgerPaymentFilteringParamsError
-} = require('../errors')
-
-const _paramsMap = {
-  default: {
-    symbol: 'symbol',
-    start: 'start',
-    end: 'end',
-    limit: 'limit'
-  },
-
-  candles: {
-    timeframe: 'timeframe',
-    symbol: 'symbol',
-    section: 'section',
-    sort: 'query.sort',
-    start: 'query.start',
-    end: 'query.end',
-    limit: 'query.limit'
-  },
-  ledgers: {
-    start: 'start',
-    end: 'end',
-    limit: 'limit',
-    symbol: 'filters.ccy',
-    category: 'filters.category'
-  },
-  statusMessages: {
-    type: 'type',
-    symbol: 'keys'
-  },
-  positionsAudit: {
-    start: 'start',
-    end: 'end',
-    limit: 'limit',
-    id: 'id'
-  },
-  orderTrades: {
-    start: 'start',
-    end: 'end',
-    limit: 'limit',
-    id: 'orderId'
-  },
-  tickersHistory: {
-    symbol: 'symbols',
-    start: 'start',
-    end: 'end',
-    limit: 'limit'
-  },
-  payInvoiceList: {
-    start: 'start',
-    end: 'end',
-    limit: 'limit',
-    id: 'id'
-  },
-  trades: {
-    symbol: 'symbol',
-    start: 'start',
-    end: 'end',
-    limit: 'limit',
-    sort: 'sort'
-  },
-  accountTrades: {
-    symbol: 'symbol',
-    start: 'start',
-    end: 'end',
-    limit: 'limit',
-    sort: 'sort'
-  },
-  movements: {
-    symbol: 'ccy',
-    start: 'start',
-    end: 'end',
-    limit: 'limit',
-    address: 'address',
-    id: 'id'
-  }
-}
+} = require('../../errors')
+const {
+  getParamsMap
+} = require('./helpers')
 
 const _paramsSchemasMap = {
   payInvoiceList: 'paramsSchemaForPayInvoiceList',
@@ -101,13 +28,6 @@ const _paramsSchemasMap = {
   orderTrades: 'paramsSchemaForOrderTradesApi',
   candles: 'paramsSchemaForCandlesApi',
   default: 'paramsSchemaForApi'
-}
-
-const _getParamsMap = (
-  method,
-  map = _paramsMap
-) => {
-  return map?.[method] ?? map.default
 }
 
 const _getSchemaNameByMethodName = (
@@ -285,7 +205,7 @@ const _getParams = (
     end: getDateNotMoreNow(params.end),
     limit: getMethodLimit(limit, methodApi)
   }
-  const paramsMap = _getParamsMap(methodApi)
+  const paramsMap = getParamsMap(methodApi)
   const queryParams = Object.entries(paramsMap)
     .reduce((accum, [inParamName, queryParamNamesStr]) => {
       const queryParamNamesArr = queryParamNamesStr.split('.')

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -146,6 +146,15 @@ const paramsSchemaForWeightedAveragesReportApi = {
   }
 }
 
+const paramsSchemaForMovementInfo = {
+  type: 'object',
+  properties: {
+    id: {
+      type: 'integer'
+    }
+  }
+}
+
 const paramsSchemaForCandlesCsv = {
   type: 'object',
   properties: {
@@ -368,5 +377,6 @@ module.exports = {
   paramsSchemaForCandlesApi,
   paramsSchemaForCandlesCsv,
   paramsSchemaForWeightedAveragesReportApi,
-  paramsSchemaForWeightedAveragesReportApiCsv
+  paramsSchemaForWeightedAveragesReportApiCsv,
+  paramsSchemaForMovementInfo
 }

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -37,7 +37,7 @@ class ReportService extends Api {
     const rest = this._getREST(args?.auth)
     const { authToken } = args?.params ?? {}
 
-    return rest.invalidateAuthToken(authToken)
+    return rest.invalidateAuthToken({ authToken })
   }
 
   _getUserInfo (args) {

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -506,6 +506,17 @@ class ReportService extends Api {
     }, 'getMovements', args, cb)
   }
 
+  getMovementInfo (space, args, cb) {
+    return this._responder(async () => {
+      checkParams(args, 'paramsSchemaForMovementInfo', ['id'])
+
+      const { auth, params } = args ?? {}
+      const rest = this._getREST(auth)
+
+      return await rest.movementInfo({ id: params?.id })
+    }, 'getMovementInfo', args, cb)
+  }
+
   getFundingOfferHistory (space, args, cb) {
     return this._responder(() => {
       return this._prepareApiResponse(

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -233,12 +233,12 @@ class ReportService extends Api {
 
   updateSettings (space, args, cb) {
     return this._responder(async () => {
-      const { auth, params } = { ...args }
-      const { settings = {} } = { ...params }
+      const { auth, params } = args ?? {}
+      const { settings = {} } = params ?? {}
 
       const rest = this._getREST(auth)
 
-      return rest.updateSettings(settings)
+      return rest.updateSettings({ settings })
     }, 'updateSettings', args, cb)
   }
 

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -11,6 +11,9 @@ const {
   filterModels,
   parsePositionsAuditId
 } = require('./helpers')
+const {
+  omitPrivateModelFields
+} = require('./helpers/prepare-response/helpers')
 const { AuthError } = require('./errors')
 const TYPES = require('./di/types')
 
@@ -289,7 +292,9 @@ class ReportService extends Api {
   getActivePositions (space, args, cb) {
     return this._responder(async () => {
       const rest = this._getREST(args.auth)
-      const positions = await rest.positions()
+      const positions = omitPrivateModelFields(
+        await rest.positions()
+      )
 
       return Array.isArray(positions)
         ? positions.filter(({ status }) => status === 'ACTIVE')
@@ -318,7 +323,7 @@ class ReportService extends Api {
 
       const rest = this._getREST(args.auth)
 
-      return rest.wallets()
+      return omitPrivateModelFields(await rest.wallets())
     }, 'getWallets', args, cb)
   }
 
@@ -487,7 +492,9 @@ class ReportService extends Api {
     return this._responder(async () => {
       const rest = this._getREST(args.auth)
 
-      const _res = await rest.activeOrders()
+      const _res = omitPrivateModelFields(
+        await rest.activeOrders()
+      )
 
       return parseFields(_res, { executed: true })
     }, 'getActiveOrders', args, cb)
@@ -513,7 +520,9 @@ class ReportService extends Api {
       const { auth, params } = args ?? {}
       const rest = this._getREST(auth)
 
-      const res = await rest.movementInfo({ id: params?.id })
+      const res = omitPrivateModelFields(
+        await rest.movementInfo({ id: params?.id })
+      )
 
       return Array.isArray(res)
         ? res[0] ?? {}
@@ -577,7 +586,9 @@ class ReportService extends Api {
       const { auth } = { ...args }
       const rest = this._getREST(auth, { timeout: 30000 })
 
-      const res = await rest.accountSummary()
+      const res = omitPrivateModelFields(
+        await rest.accountSummary()
+      )
 
       return Array.isArray(res) ? res : [res]
     }, 'getAccountSummary', args, cb)

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -222,12 +222,12 @@ class ReportService extends Api {
 
   getSettings (space, args, cb) {
     return this._responder(async () => {
-      const { auth, params } = { ...args }
-      const { keys = [] } = { ...params }
+      const { auth, params } = args ?? {}
+      const { keys = [] } = params ?? {}
 
       const rest = this._getREST(auth)
 
-      return rest.getSettings(keys)
+      return rest.getSettings({ keys })
     }, 'getSettings', args, cb)
   }
 

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -513,7 +513,11 @@ class ReportService extends Api {
       const { auth, params } = args ?? {}
       const rest = this._getREST(auth)
 
-      return await rest.movementInfo({ id: params?.id })
+      const res = await rest.movementInfo({ id: params?.id })
+
+      return Array.isArray(res)
+        ? res[0] ?? {}
+        : res
     }, 'getMovementInfo', args, cb)
   }
 

--- a/workers/loc.api/service.report.js
+++ b/workers/loc.api/service.report.js
@@ -71,11 +71,11 @@ class ReportService extends Api {
   }
 
   async _getConf (opts) {
-    const { keys } = { ...opts }
-    const _keys = Array.isArray(keys) ? keys : [keys]
+    const { keys: _keys } = opts ?? {}
+    const keys = Array.isArray(_keys) ? _keys : [_keys]
     const rest = this._getREST({})
 
-    const res = await rest.conf(_keys)
+    const res = await rest.conf({ keys })
 
     return Array.isArray(res) ? res : []
   }


### PR DESCRIPTION
This PR adds currency movement info endpoint https://docs.bitfinex.com/reference/movement-info. Due to the changed signatures of the `bitfinex-api-node` library methods in the new major version, to add this endpoint, the way of passing parameters to all bfx api methods is also changed/refactored

---

Basic changes:
- adds `getMovementInfo` endpoint
- reworks params processing to support new bfx rest api signatures
- bumps `bitfinex-api-node` version up to 6.0.0
- adds test coverage for `getMovementInfo` endpoint

---

Request example:
```jsonc
{
  "auth": {
    "apiKey": "user-api-key",
    "apiSecret": "user-api-secret"
  },
  "method": "getMovementInfo",
  "params": {
    "id": 12345678
  }
}
```

Response example:
```jsonc
{
  "jsonrpc": "2.0",
  "result": {
    "id": 12345678,
    "currency": "UST",
    "currencyName": "TETHERUSE",
    "remark": "0x123456789a12abc1abcde1234ab1a1234abcefg1, canceled by User",
    "mtsStarted": 1614066589000,
    "mtsUpdated": 1614066972000,
    "status": "CANCELED",
    "amount": -21.123,
    "fees": -12.321,
    "destinationAddress": "0x123456789a12abc1abcde1234ab1a1234abcefg1",
    "memo": null,
    "transactionId": null,
    "note": "test 1",
    "bankFees": 0,
    "bankRouterId": null,
    "externalBankMovId": null,
    "externalBankMovStatus": null,
    "externalBankMovDescription": null,
    "externalBankAccInfo": null,
    "_isDataFromApiV2": true
  },
  "id": null
}
```