### PR TITLE
Improve bfx api error handling

### DIFF
--- a/workers/loc.api/helpers/api-errors-testers.js
+++ b/workers/loc.api/helpers/api-errors-testers.js
@@ -1,63 +1,70 @@
 'use strict'
 
+const _getErrorString = (err) => {
+  const response = err?.response
+    ? ` ${err.response}`
+    : ''
+  return `${err.toString()}${response}`
+}
+
 const isAuthError = (err) => {
-  return /(token: invalid)|(missing api key or secret)|(apikey: digest invalid)|(apikey: invalid)|(ERR_AUTH_UNAUTHORIZED)/.test(err.toString())
+  return /(token: invalid)|(missing api key or secret)|(apikey: digest invalid)|(apikey: invalid)|(ERR_AUTH_UNAUTHORIZED)/.test(_getErrorString(err))
 }
 
 const isRateLimitError = (err) => {
-  return /(ERR(_RATE)?_LIMIT)|(ratelimit)/.test(err.toString())
+  return /(ERR(_RATE)?_LIMIT)|(ratelimit)/.test(_getErrorString(err))
 }
 
 const isNonceSmallError = (err) => {
-  return /nonce: small/.test(err.toString())
+  return /nonce: small/.test(_getErrorString(err))
 }
 
 const isUserIsNotMerchantError = (err) => {
-  return /ERR_INVOICE_LIST: ERR_PAY_USER_NOT_MERCHANT/.test(err.toString())
+  return /ERR_INVOICE_LIST: ERR_PAY_USER_NOT_MERCHANT/.test(_getErrorString(err))
 }
 
 const isSymbolInvalidError = (err) => {
-  return /(symbol: invalid)|(currency: invalid)/.test(err.toString())
+  return /(symbol: invalid)|(currency: invalid)/.test(_getErrorString(err))
 }
 
 const isENetUnreachError = (err) => {
-  return /ENETUNREACH/.test(err.toString())
+  return /ENETUNREACH/.test(_getErrorString(err))
 }
 
 const isEConnResetError = (err) => {
-  return /ECONNRESET/.test(err.toString())
+  return /ECONNRESET/.test(_getErrorString(err))
 }
 
 const isETimedOutError = (err) => {
-  return /ETIMEDOUT/.test(err.toString())
+  return /ETIMEDOUT/.test(_getErrorString(err))
 }
 
 const isEAiAgainError = (err) => {
-  return /EAI_AGAIN/.test(err.toString())
+  return /EAI_AGAIN/.test(_getErrorString(err))
 }
 
 const isEConnRefusedError = (err) => {
-  return /ECONNREFUSED/.test(err.toString())
+  return /ECONNREFUSED/.test(_getErrorString(err))
 }
 
 const isENotFoundError = (err) => {
-  return /ENOTFOUND/.test(err.toString())
+  return /ENOTFOUND/.test(_getErrorString(err))
 }
 
 const isESocketTimeoutError = (err) => {
-  return /ESOCKETTIMEDOUT/.test(err.toString())
+  return /ESOCKETTIMEDOUT/.test(_getErrorString(err))
 }
 
 const isEHostUnreachError = (err) => {
-  return /EHOSTUNREACH/.test(err.toString())
+  return /EHOSTUNREACH/.test(_getErrorString(err))
 }
 
 const isEProtoError = (err) => {
-  return /EPROTO/.test(err.toString())
+  return /EPROTO/.test(_getErrorString(err))
 }
 
 const isTempUnavailableError = (err) => {
-  return /temporarily_unavailable/.test(err.toString())
+  return /temporarily_unavailable/.test(_getErrorString(err))
 }
 
 const isENetError = (err) => (

--- a/workers/loc.api/responder/index.js
+++ b/workers/loc.api/responder/index.js
@@ -105,11 +105,19 @@ const _getErrorMetadata = (args, err) => {
     data = null
   } = errWithMetadata
 
+  const _message = err?.status
+    ? `${message}
+  - BFX_API_STATUS: ${err.status}
+  - BFX_API_STATUS_TEXT: ${err.statustext ?? 'Status text is not abailable'}
+  - BFX_API_RAW_BODY_CODE: ${err.code ?? 'Code is not abailable'}
+  - BFX_API_RAW_BODY_RESPONSE: ${err.response ?? 'Response is not abailable'}`
+    : message
+
   const error = Object.assign(
     errWithMetadata,
     {
       statusCode: code,
-      statusMessage: message,
+      statusMessage: _message,
       data
     }
   )


### PR DESCRIPTION
This PR improves BFX API error handling due to the last major changes of the rest-api lib: https://github.com/bitfinexcom/bfx-api-node-rest/blame/master/lib/rest2.js#LL157C14-L170C4

---

The issue is when we make a call to `payInvoiceList` endpoint with a user who's `NOT_MERCHANT`, api send an error in the raw body `ERR_INVOICE_LIST: ERR_PAY_USER_NOT_MERCHANT` instead of `statusText`. We should handle this case

---

Basic changes:
- Improves bfx api error handling
- Extends error logging to see bfx api errors

---

Logging example:
![Screenshot from 2023-06-16 11-48-06](https://github.com/bitfinexcom/bfx-report/assets/16489235/d35224ab-5598-415e-ac18-33cbc463f793)

