### PR TITLE
Prevent proxy all HTML of bfx api error

### DIFF
--- a/workers/loc.api/helpers/api-errors-testers.js
+++ b/workers/loc.api/helpers/api-errors-testers.js
@@ -67,6 +67,10 @@ const isTempUnavailableError = (err) => {
   return /temporarily_unavailable/.test(_getErrorString(err))
 }
 
+const isForbiddenError = (err) => {
+  return /forbidden/i.test(_getErrorString(err))
+}
+
 const isENetError = (err) => (
   isENetUnreachError(err) ||
   isEConnResetError(err) ||
@@ -96,5 +100,6 @@ module.exports = {
   isEHostUnreachError,
   isEProtoError,
   isTempUnavailableError,
-  isENetError
+  isENetError,
+  isForbiddenError
 }

--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -32,7 +32,8 @@ const {
   isEConnRefusedError,
   isENotFoundError,
   isESocketTimeoutError,
-  isENetError
+  isENetError,
+  isForbiddenError
 } = require('./api-errors-testers')
 const {
   accountCache,
@@ -73,6 +74,7 @@ module.exports = {
   isENotFoundError,
   isESocketTimeoutError,
   isENetError,
+  isForbiddenError,
   accountCache,
   parseFields,
   parseLoginsExtraDataFields,

--- a/workers/loc.api/responder/__test__/mockedHtmlBody403.html
+++ b/workers/loc.api/responder/__test__/mockedHtmlBody403.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<!--[if lt IE 7]> <html class="no-js ie6 oldie" lang="en-US"> <![endif]-->
+<!--[if IE 7]>    <html class="no-js ie7 oldie" lang="en-US"> <![endif]-->
+<!--[if IE 8]>    <html class="no-js ie8 oldie" lang="en-US"> <![endif]-->
+<!--[if gt IE 8]><!-->
+<html class="no-js" lang="en-US"> <!--<![endif]-->
+
+<head>
+  <title>Access denied | api.staging.bitfinex.com used Cloudflare to restrict access</title>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+  <meta name="robots" content="noindex, nofollow" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <link rel="stylesheet" id="cf_styles-css" href="/cdn-cgi/styles/main.css" />
+</head>
+
+<body>
+  <div id="cf-wrapper">
+    <div class="cf-alert cf-alert-error cf-cookie-error hidden" id="cookie-alert" data-translate="enable_cookies">Please
+      enable cookies.</div>
+    <div id="cf-error-details" class="p-0">
+      <header class="mx-auto pt-10 lg:pt-6 lg:px-8 w-240 lg:w-full mb-15 antialiased">
+        <h1 class="inline-block md:block mr-2 md:mb-2 font-light text-60 md:text-3xl text-black-dark leading-tight">
+          <span data-translate="error">Error</span>
+          <span>1006</span>
+        </h1>
+        <span class="inline-block md:block heading-ray-id font-mono text-15 lg:text-sm lg:leading-relaxed">Ray ID:
+          1234567890 &bull;</span>
+        <span class="inline-block md:block heading-ray-id font-mono text-15 lg:text-sm lg:leading-relaxed">2023-01-01
+          12:00:00 UTC</span>
+        <h2 class="text-gray-600 leading-1.3 text-3xl lg:text-2xl font-light">Access denied</h2>
+      </header>
+      <section class="w-240 lg:w-full mx-auto mb-8 lg:px-8">
+        <div id="what-happened-section" class="w-1/2 md:w-full">
+          <h2 class="text-3xl leading-tight font-normal mb-4 text-black-dark antialiased"
+            data-translate="what_happened">What happened?</h2>
+          <p>The owner of this website (api.staging.bitfinex.com) has banned your IP address (12.123.123.12).</p>
+        </div>
+      </section>
+      <div class="feedback-hidden py-8 text-center" id="error-feedback">
+        <div id="error-feedback-survey" class="footer-line-wrapper">
+          Was this page helpful?
+          <button class="border border-solid bg-white cf-button cursor-pointer ml-4 px-4 py-2 rounded"
+            id="feedback-button-yes" type="button">Yes</button>
+          <button class="border border-solid bg-white cf-button cursor-pointer ml-4 px-4 py-2 rounded"
+            id="feedback-button-no" type="button">No</button>
+        </div>
+        <div class="feedback-success feedback-hidden" id="error-feedback-success">
+          Thank you for your feedback!
+        </div>
+      </div>
+      <div
+        class="cf-error-footer cf-wrapper w-240 lg:w-full py-10 sm:py-4 sm:px-8 mx-auto text-center sm:text-left border-solid border-0 border-t border-gray-300">
+        <p class="text-13">
+          <span class="cf-footer-item sm:block sm:mb-1">Cloudflare Ray ID: <strong
+              class="font-semibold">1234567890</strong></span>
+          <span class="cf-footer-separator sm:hidden">&bull;</span>
+          <span id="cf-footer-item-ip" class="cf-footer-item hidden sm:block sm:mb-1">
+            Your IP:
+            <button type="button" id="cf-footer-ip-reveal" class="cf-footer-ip-reveal-btn">Click to reveal</button>
+            <span class="hidden" id="cf-footer-ip">12.123.123.12</span>
+            <span class="cf-footer-separator sm:hidden">&bull;</span>
+          </span>
+          <span class="cf-footer-item sm:block sm:mb-1"><span>Performance &amp; security by</span> <a
+              rel="noopener noreferrer" href="https://www.cloudflare.com/5xx-error-landing" id="brand_link"
+              target="_blank">Cloudflare</a></span>
+        </p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/workers/loc.api/responder/__test__/responder.spec.js
+++ b/workers/loc.api/responder/__test__/responder.spec.js
@@ -1,0 +1,87 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const { assert } = require('chai')
+
+require('reflect-metadata')
+const responder = require('../index')
+const AbstractWSEventEmitter = require('../../abstract.ws.event.emitter')
+
+const JSON_RPC_VERSION = '2.0'
+const name = 'mockedResponderCall'
+const args = { id: 5 }
+const mockedHtmlBody403 = fs.readFileSync(path.join(
+  __dirname, 'mockedHtmlBody403.html'
+))
+
+const _makeApiError = (resp, rawBody) => {
+  const err = new Error(`HTTP code ${resp.status} ${resp.statusText || ''}`)
+  err.status = resp.status
+  err.statustext = resp.statusText
+  try {
+    const [, code, response] = JSON.parse(rawBody)
+    err.code = code
+    err.response = response
+  } catch (_err) {
+    err.response = rawBody
+  }
+
+  return err
+}
+
+describe('Responder service', () => {
+  let mockedResponder = null
+
+  before(function () {
+    const mockedContainer = {}
+    const mockedLogger = {
+      debug (message) {
+        assert.isString(message)
+      },
+      error (message) {
+        assert.isString(message)
+      }
+    }
+    const mockedWsEventEmitterFactory = () => new (class WSEventEmitter extends AbstractWSEventEmitter {
+      emitBfxUnamePwdAuthRequiredToOne (data, auth) {
+        assert.isObject(data)
+        assert.isObject(auth)
+      }
+    })()
+
+    mockedResponder = responder(
+      mockedContainer,
+      mockedLogger,
+      mockedWsEventEmitterFactory
+    )
+  })
+
+  it('handle HTML error', async function () {
+    await mockedResponder(async () => {
+      throw _makeApiError({
+        status: 403,
+        statustext: 'Forbidden'
+      }, mockedHtmlBody403)
+    }, name, args, (err, res) => {
+      assert.isNull(err)
+
+      assert.isObject(res)
+      assert.propertyVal(res, 'id', 5)
+      assert.propertyVal(res, 'jsonrpc', JSON_RPC_VERSION)
+      assert.isObject(res.error)
+      assert.propertyVal(res.error, 'code', 403)
+      assert.propertyVal(res.error, 'message', 'Forbidden')
+      assert.isObject(res.error.data)
+      assert.isObject(res.error.data.bfxApiErrorMessage)
+
+      assert.containsAllKeys(res.error.data.bfxApiErrorMessage, [
+        'bfxApiStatus',
+        'bfxApiStatusText',
+        'bfxApiRawBodyCode',
+        'isBfxApiRawBodyResponseHtml',
+        'bfxApiRawBodyResponse'
+      ])
+    })
+  })
+})

--- a/workers/loc.api/responder/index.js
+++ b/workers/loc.api/responder/index.js
@@ -15,7 +15,35 @@ const {
   AuthError
 } = require('../errors')
 
+const _htmlRegExp = /<html.*>/i
+const _htmlTitleRegExp = /<title.*>(?<body>.*)<\/title.*>/i
+
 const JSON_RPC_VERSION = '2.0'
+
+const _isHtml = (res) => (_htmlRegExp.test(res))
+
+const _findHtmlTitle = (res) => (
+  res?.match(_htmlTitleRegExp).groups?.body ?? 'HTML title not found'
+)
+
+const _getBfxApiErrorMetadata = (err) => {
+  if (!err?.status) {
+    return null
+  }
+
+  const isHtml = _isHtml(err.response)
+  const body = isHtml
+    ? _findHtmlTitle(err.response)
+    : err.response ?? 'Response is not abailable'
+
+  return {
+    bfxApiStatus: err.status,
+    bfxApiStatusText: err.statustext ?? 'Status text is not abailable',
+    bfxApiRawBodyCode: err.code ?? 'Code is not abailable',
+    isBfxApiRawBodyResponseHtml: isHtml ? 'Yes' : 'No',
+    bfxApiRawBodyResponse: body
+  }
+}
 
 const _prepareErrorData = (err, name) => {
   const { message = 'ERR_ERROR_HAS_OCCURRED' } = err
@@ -29,7 +57,10 @@ const _prepareErrorData = (err, name) => {
     ? `\n  - STATUS_MESSAGE: ${err.statusMessage}`
     : ''
   const _data = err.data
-    ? `\n  - DATA: ${JSON.stringify(err.data)}`
+    ? `\n  - DATA: ${JSON.stringify(err.data, null, 2)
+      .split('\n')
+      .map((v, i) => (i === 0 ? v : `    ${v}`))
+      .join('\n')}`
     : ''
   const stackTrace = (err.stack || err)
     ? `\n  - STACK_TRACE ${err.stack || err}`
@@ -105,20 +136,20 @@ const _getErrorMetadata = (args, err) => {
     data = null
   } = errWithMetadata
 
-  const _message = err?.status
-    ? `${message}
-  - BFX_API_STATUS: ${err.status}
-  - BFX_API_STATUS_TEXT: ${err.statustext ?? 'Status text is not abailable'}
-  - BFX_API_RAW_BODY_CODE: ${err.code ?? 'Code is not abailable'}
-  - BFX_API_RAW_BODY_RESPONSE: ${err.response ?? 'Response is not abailable'}`
-    : message
+  const bfxApiErrorMessage = _getBfxApiErrorMetadata(err)
+  const extendedData = bfxApiErrorMessage
+    ? {
+        bfxApiErrorMessage,
+        ...data
+      }
+    : data
 
   const error = Object.assign(
     errWithMetadata,
     {
       statusCode: code,
-      statusMessage: _message,
-      data
+      statusMessage: message,
+      data: extendedData
     }
   )
 

--- a/workers/loc.api/responder/index.js
+++ b/workers/loc.api/responder/index.js
@@ -7,7 +7,8 @@ const {
   isRateLimitError,
   isNonceSmallError,
   isUserIsNotMerchantError,
-  isSymbolInvalidError
+  isSymbolInvalidError,
+  isForbiddenError
 } = require('../helpers')
 
 const {
@@ -121,6 +122,12 @@ const _getErrorWithMetadataForNonBaseError = (args, err) => {
     err.statusCode = 500
     err.statusMessage = `Invalid symbol error, '${symbol}' is not supported`
     err.data = [{ symbol }]
+
+    return err
+  }
+  if (isForbiddenError(err)) {
+    err.statusCode = 403
+    err.statusMessage = 'Forbidden'
 
     return err
   }


### PR DESCRIPTION
This PR prevents proxying all HTML of the bfx api error

---

In some cases, the bfx api may respond just HTML instead of expected json in the raw body https://github.com/bitfinexcom/bfx-api-node-rest/blame/master/lib/rest2.js#L166
For example: maintenance mode, nginx 502 `Bad Gateway` error, 403 `Forbidden` for the staging server,  check the screenshot:

![Screenshot from 2023-06-16 14-32-19-123](https://github.com/bitfinexcom/bfx-report/assets/16489235/2df0f650-5378-4166-a29e-3199a5a98867)

---

The idea is:
- don't proxy all HTML
- extract a string of the `title` tag to use as a description of the error
- and pass it to the corresponding field of an error

---

Basic changes:
- Prevents proxying all HTML of bfx api error
- Adds `forbidden` resource error tester
- Handles `forbidden` resource error
- Adds test cases for response service for handling error with html and plain text in the  response body

---

Request example:
```jsonc
{
  "auth": {
    "apiKey": "api_key",
    "apiSecret": "api_secret"
  },
  "method": "verifyUser"
}
```

Response example:
```jsonc
{
  "jsonrpc": "2.0",
  "error": {
    "code": 403,
    "message": "Forbidden",
    "data": {
      "bfxApiErrorMessage": {
        "bfxApiStatus": 403,
        "bfxApiStatusText": "Forbidden",
        "bfxApiRawBodyCode": "Code is not abailable",
        "isBfxApiRawBodyResponseHtml": "Yes",
        "bfxApiRawBodyResponse": "Access denied | api.staging.bitfinex.com used Cloudflare to restrict access"
      }
    }
  },
  "id": null
}
```

Error logging examples:

![Screenshot from 2023-06-20 08-52-46](https://github.com/bitfinexcom/bfx-report/assets/16489235/e1252f7e-b1c5-40a5-9d25-0a6cb1be2cec)

![Screenshot from 2023-06-21 08-27-57](https://github.com/bitfinexcom/bfx-report/assets/16489235/c2ebbd44-380c-4063-acc2-c62fdbde73ff)
