### PR TITLE
Decrease weighted averages limit to 50k

### DIFF
--- a/workers/loc.api/weighted.averages.report/index.js
+++ b/workers/loc.api/weighted.averages.report/index.js
@@ -64,7 +64,7 @@ class WeightedAveragesReport {
   }
 
   async _getWeightedAveragesReportFromApi (args) {
-    const limit = 100_000
+    const limit = 50_000
     const symbols = args?.params?.symbol ?? []
 
     const weightedAverages = []


### PR DESCRIPTION
This PR decreases the limit of trades selection for the `Weighted Averages` calculation to `50k`  due to changing of the BFX API endpoint