### PR TITLE
Increase weighted averages limit to 100k

### DIFF
--- a/workers/loc.api/weighted.averages.report/index.js
+++ b/workers/loc.api/weighted.averages.report/index.js
@@ -64,7 +64,7 @@ class WeightedAveragesReport {
   }
 
   async _getWeightedAveragesReportFromApi (args) {
-    const limit = 50_000
+    const limit = 100_000
     const symbols = args?.params?.symbol ?? []
 
     const weightedAverages = []


### PR DESCRIPTION
This PR Increases the limit of trades selection for the `Weighted Averages` calculation to `100k` due to changing of the `BFX API` endpoint