### PR TITLE
Add rate limit router

### DIFF
--- a/workers/loc.api/bfx.api.router/index.js
+++ b/workers/loc.api/bfx.api.router/index.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const { decorateInjectable } = require('../di/utils')
+
+class BfxApiRouter {
+  // Method does an idle job to be overridden in framework mode
+  route (methodName, method) {
+    return method()
+  }
+}
+
+decorateInjectable(BfxApiRouter)
+
+module.exports = BfxApiRouter

--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -31,6 +31,7 @@ const {
   weightedAveragesReportCsvWriter
 } = require('../generate-csv/csv-writer')
 const WeightedAveragesReport = require('../weighted.averages.report')
+const BfxApiRouter = require('../bfx.api.router')
 
 module.exports = ({
   rService,
@@ -76,10 +77,16 @@ module.exports = ({
         ]
       )
     )
+    bind(TYPES.BfxApiRouter)
+      .to(BfxApiRouter)
+      .inSingletonScope()
     bind(TYPES.GetREST).toConstantValue(
       bindDepsToFn(
         getREST,
-        [TYPES.CONF]
+        [
+          TYPES.CONF,
+          TYPES.BfxApiRouter
+        ]
       )
     )
     bind(TYPES.GrcBfxReq).toConstantValue(

--- a/workers/loc.api/di/types.js
+++ b/workers/loc.api/di/types.js
@@ -33,5 +33,6 @@ module.exports = {
   AbstractWSEventEmitter: Symbol.for('AbstractWSEventEmitter'),
   GetDataFromApi: Symbol.for('GetDataFromApi'),
   WeightedAveragesReport: Symbol.for('WeightedAveragesReport'),
-  WeightedAveragesReportCsvWriter: Symbol.for('WeightedAveragesReportCsvWriter')
+  WeightedAveragesReportCsvWriter: Symbol.for('WeightedAveragesReportCsvWriter'),
+  BfxApiRouter: Symbol.for('BfxApiRouter')
 }

--- a/workers/loc.api/helpers/get-rest.js
+++ b/workers/loc.api/helpers/get-rest.js
@@ -263,7 +263,7 @@ module.exports = (conf) => {
       authToken: _authToken = ''
     } = auth
     const {
-      timeout = 20000
+      timeout = 90000
     } = opts ?? {}
 
     /*

--- a/workers/loc.api/helpers/get-rest.js
+++ b/workers/loc.api/helpers/get-rest.js
@@ -14,14 +14,46 @@ const isTestEnv = process.env.NODE_ENV === 'test'
 let bfxInstance = null
 
 const rateLimitCheckerMaps = new Map()
-// TODO:
 const _rateLimitForMethodName = new Map([
-  ['trades', 45]
+  ['generateToken', null],
+  ['invalidateAuthToken', null],
+  ['userInfo', 90],
+  ['symbols', 90],
+  ['futures', 90],
+  ['currencies', 90],
+  ['inactiveSymbols', 90],
+  ['conf', 90],
+  ['positionsSnapshot', 90],
+  ['getSettings', 90],
+  ['updateSettings', 90],
+  ['tickersHistory', 30],
+  ['positionsHistory', 90],
+  ['positions', 90],
+  ['positionsAudit', 90],
+  ['wallets', 90],
+  ['ledgers', 90],
+  ['payInvoiceList', 90],
+  ['accountTrades', 90],
+  ['fundingTrades', 90],
+  ['trades', 90],
+  ['statusMessages', 90],
+  ['candles', 90],
+  ['orderTrades', 90],
+  ['orderHistory', 90],
+  ['activeOrders', 90],
+  ['movements', 90],
+  ['movementInfo', 90],
+  ['fundingOfferHistory', 90],
+  ['fundingLoanHistory', 90],
+  ['fundingCreditHistory', 90],
+  ['accountSummary', 90],
+  ['logins', 90],
+  ['changeLogs', 90]
 ])
 
 class RateLimitChecker {
   constructor (conf) {
-    this.rateLimit = conf?.rateLimit ?? 45
+    this.rateLimit = conf?.rateLimit ?? 10
     this.msPeriod = conf?.msPeriod ?? 60000
 
     this._calls = []


### PR DESCRIPTION
This PR adds Rate Limit router to be overridden in the `framework` mode

---

The router aims to control BFX API requests bandwidth. It does an idle job here and the main logic is implemented in the `bfx-reports-framework`
Also bumps api call timeout to 90s
