### PR TITLE
Add last/first trades mts into weighted averages for framework

### DIFF
--- a/workers/loc.api/weighted.averages.report/index.js
+++ b/workers/loc.api/weighted.averages.report/index.js
@@ -345,6 +345,12 @@ class WeightedAveragesReport {
         cumulativeAmount = 0
       } = val ?? {}
 
+      const tradesBySymbol = trades.filter((t) => t.symbol === symbol)
+      const firstTradeMts = tradesBySymbol[tradesBySymbol.length - 1]
+        ?.mtsCreate ?? null
+      const lastTradeMts = tradesBySymbol[0]
+        ?.mtsCreate ?? null
+
       return {
         symbol,
         buyingWeightedPrice,
@@ -352,7 +358,9 @@ class WeightedAveragesReport {
         sellingWeightedPrice,
         sellingAmount,
         cumulativeWeightedPrice,
-        cumulativeAmount
+        cumulativeAmount,
+        firstTradeMts,
+        lastTradeMts
       }
     })
   }


### PR DESCRIPTION
This PR adds last/first trades mts into the `weighted averages` report for the framework mode