### PR TITLE
Fix handling bfx api invalid credentials error

### DIFF
--- a/workers/loc.api/helpers/api-errors-testers.js
+++ b/workers/loc.api/helpers/api-errors-testers.js
@@ -8,7 +8,7 @@ const _getErrorString = (err) => {
 }
 
 const isAuthError = (err) => {
-  return /(token: invalid)|(missing api key or secret)|(apikey: digest invalid)|(apikey: invalid)|(ERR_AUTH_UNAUTHORIZED)/i.test(_getErrorString(err))
+  return /(token: invalid)|(missing api key or secret)|(apikey: digest invalid)|(apikey: invalid)|(ERR_AUTH_UNAUTHORIZED)|(ERR_AUTH_API: ERR_INVALID_CREDENTIALS)/i.test(_getErrorString(err))
 }
 
 const isRateLimitError = (err) => {


### PR DESCRIPTION
This PR fixes handling bfx api `ERR_AUTH_API: ERR_INVALID_CREDENTIALS` error to prevent showing `500 Internal Server Error` and  error modal dialog in the electron app

---

**Related** to this issue:
- https://github.com/bitfinexcom/bfx-report-electron/issues/228
