### PR TITLE
Remove cumulative weighted price and add cost/sale columns

### DIFF
--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -1802,11 +1802,11 @@ describe('API', () => {
         'symbol',
         'buyingWeightedPrice',
         'buyingAmount',
+        'cost',
         'sellingWeightedPrice',
         'sellingAmount',
-        'cumulativeAmount',
-        'cost',
         'sale',
+        'cumulativeAmount',
         'firstTradeMts',
         'lastTradeMts'
       ])

--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -1805,6 +1805,8 @@ describe('API', () => {
         'sellingWeightedPrice',
         'sellingAmount',
         'cumulativeAmount',
+        'cost',
+        'sale',
         'firstTradeMts',
         'lastTradeMts'
       ])

--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -1804,7 +1804,6 @@ describe('API', () => {
         'buyingAmount',
         'sellingWeightedPrice',
         'sellingAmount',
-        'cumulativeWeightedPrice',
         'cumulativeAmount',
         'firstTradeMts',
         'lastTradeMts'

--- a/workers/loc.api/generate-csv/csv-writer/weighted-averages-report-csv-writer.js
+++ b/workers/loc.api/generate-csv/csv-writer/weighted-averages-report-csv-writer.js
@@ -43,7 +43,7 @@ module.exports = (
   wStream.setMaxListeners(50)
 
   const headerStringifier = stringify(
-    { columns: ['empty', 'buy', 'empty', 'sell', 'empty', 'cumulative', 'empty'] }
+    { columns: ['empty', 'buy', 'empty', 'empty', 'sell', 'empty', 'empty', 'cumulative', 'empty'] }
   )
   const resStringifier = stringify({
     header: true,

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -1061,11 +1061,11 @@ class CsvJobData {
         symbol: 'PAIR',
         buyingWeightedPrice: 'WEIGHTED PRICE',
         buyingAmount: 'AMOUNT',
+        cost: 'COST',
         sellingWeightedPrice: 'WEIGHTED PRICE',
         sellingAmount: 'AMOUNT',
-        cumulativeAmount: 'AMOUNT',
-        cost: 'COST',
         sale: 'SALE',
+        cumulativeAmount: 'AMOUNT',
         firstTradeMts: 'First Trade',
         lastTradeMts: 'Last Trade'
       },

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -1064,6 +1064,8 @@ class CsvJobData {
         sellingWeightedPrice: 'WEIGHTED PRICE',
         sellingAmount: 'AMOUNT',
         cumulativeAmount: 'AMOUNT',
+        cost: 'COST',
+        sale: 'SALE',
         firstTradeMts: 'First Trade',
         lastTradeMts: 'Last Trade'
       },

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -1063,7 +1063,6 @@ class CsvJobData {
         buyingAmount: 'AMOUNT',
         sellingWeightedPrice: 'WEIGHTED PRICE',
         sellingAmount: 'AMOUNT',
-        cumulativeWeightedPrice: 'WEIGHTED PRICE',
         cumulativeAmount: 'AMOUNT',
         firstTradeMts: 'First Trade',
         lastTradeMts: 'Last Trade'

--- a/workers/loc.api/weighted.averages.report/index.js
+++ b/workers/loc.api/weighted.averages.report/index.js
@@ -133,11 +133,11 @@ class WeightedAveragesReport {
         symbol,
         buyingWeightedPrice,
         buyingAmount: sumBuyingAmount,
+        cost,
         sellingWeightedPrice,
         sellingAmount: sumSellingAmount,
-        cumulativeAmount,
-        cost,
         sale,
+        cumulativeAmount,
         firstTradeMts,
         lastTradeMts
       })
@@ -327,11 +327,11 @@ class WeightedAveragesReport {
 
         buyingWeightedPrice,
         buyingAmount: sumBuyingAmount,
+        cost: buyingWeightedPrice * sumBuyingAmount,
         sellingWeightedPrice,
         sellingAmount: sumSellingAmount,
-        cumulativeAmount: sumAmount,
-        cost: buyingWeightedPrice * sumBuyingAmount,
-        sale: sellingWeightedPrice * sumSellingAmount
+        sale: sellingWeightedPrice * sumSellingAmount,
+        cumulativeAmount: sumAmount
       })
     }
 
@@ -339,11 +339,11 @@ class WeightedAveragesReport {
       const {
         buyingWeightedPrice = 0,
         buyingAmount = 0,
+        cost = 0,
         sellingWeightedPrice = 0,
         sellingAmount = 0,
-        cumulativeAmount = 0,
-        cost = 0,
-        sale = 0
+        sale = 0,
+        cumulativeAmount = 0
       } = val ?? {}
 
       const tradesBySymbol = trades.filter((t) => t.symbol === symbol)
@@ -356,11 +356,11 @@ class WeightedAveragesReport {
         symbol,
         buyingWeightedPrice,
         buyingAmount,
+        cost,
         sellingWeightedPrice,
         sellingAmount,
-        cumulativeAmount,
-        cost,
         sale,
+        cumulativeAmount,
         firstTradeMts,
         lastTradeMts
       }

--- a/workers/loc.api/weighted.averages.report/index.js
+++ b/workers/loc.api/weighted.averages.report/index.js
@@ -113,9 +113,7 @@ class WeightedAveragesReport {
 
       const {
         tradeCount,
-        sumBuyingSpent = 0,
         sumBuyingAmount = 0,
-        sumSellingSpent = 0,
         sumSellingAmount = 0,
         buyingWeightedPrice = 0,
         sellingWeightedPrice = 0,
@@ -128,9 +126,6 @@ class WeightedAveragesReport {
       }
 
       const cumulativeAmount = sumBuyingAmount + sumSellingAmount
-      const cumulativeWeightedPrice = cumulativeAmount === 0
-        ? 0
-        : (sumBuyingSpent + sumSellingSpent) / cumulativeAmount
 
       weightedAverages.push({
         symbol,
@@ -138,7 +133,6 @@ class WeightedAveragesReport {
         buyingAmount: sumBuyingAmount,
         sellingWeightedPrice,
         sellingAmount: sumSellingAmount,
-        cumulativeWeightedPrice,
         cumulativeAmount,
         firstTradeMts,
         lastTradeMts
@@ -328,9 +322,6 @@ class WeightedAveragesReport {
           ? 0
           : sumSellingSpent / sumSellingAmount,
         sellingAmount: sumSellingAmount,
-        cumulativeWeightedPrice: sumAmount === 0
-          ? 0
-          : sumSpent / sumAmount,
         cumulativeAmount: sumAmount
       })
     }
@@ -341,7 +332,6 @@ class WeightedAveragesReport {
         buyingAmount = 0,
         sellingWeightedPrice = 0,
         sellingAmount = 0,
-        cumulativeWeightedPrice = 0,
         cumulativeAmount = 0
       } = val ?? {}
 
@@ -357,7 +347,6 @@ class WeightedAveragesReport {
         buyingAmount,
         sellingWeightedPrice,
         sellingAmount,
-        cumulativeWeightedPrice,
         cumulativeAmount,
         firstTradeMts,
         lastTradeMts

--- a/workers/loc.api/weighted.averages.report/index.js
+++ b/workers/loc.api/weighted.averages.report/index.js
@@ -126,6 +126,8 @@ class WeightedAveragesReport {
       }
 
       const cumulativeAmount = sumBuyingAmount + sumSellingAmount
+      const cost = buyingWeightedPrice * sumBuyingAmount
+      const sale = sellingWeightedPrice * sumSellingAmount
 
       weightedAverages.push({
         symbol,
@@ -134,6 +136,8 @@ class WeightedAveragesReport {
         sellingWeightedPrice,
         sellingAmount: sumSellingAmount,
         cumulativeAmount,
+        cost,
+        sale,
         firstTradeMts,
         lastTradeMts
       })
@@ -306,6 +310,13 @@ class WeightedAveragesReport {
         ? _sumSellingAmount + execAmount
         : _sumSellingAmount
 
+      const buyingWeightedPrice = sumBuyingAmount === 0
+        ? 0
+        : sumBuyingSpent / sumBuyingAmount
+      const sellingWeightedPrice = sumSellingAmount === 0
+        ? 0
+        : sumSellingSpent / sumSellingAmount
+
       symbResMap.set(symbol, {
         sumSpent,
         sumAmount,
@@ -314,15 +325,13 @@ class WeightedAveragesReport {
         sumSellingSpent,
         sumSellingAmount,
 
-        buyingWeightedPrice: sumBuyingAmount === 0
-          ? 0
-          : sumBuyingSpent / sumBuyingAmount,
+        buyingWeightedPrice,
         buyingAmount: sumBuyingAmount,
-        sellingWeightedPrice: sumSellingAmount === 0
-          ? 0
-          : sumSellingSpent / sumSellingAmount,
+        sellingWeightedPrice,
         sellingAmount: sumSellingAmount,
-        cumulativeAmount: sumAmount
+        cumulativeAmount: sumAmount,
+        cost: buyingWeightedPrice * sumBuyingAmount,
+        sale: sellingWeightedPrice * sumSellingAmount
       })
     }
 
@@ -332,7 +341,9 @@ class WeightedAveragesReport {
         buyingAmount = 0,
         sellingWeightedPrice = 0,
         sellingAmount = 0,
-        cumulativeAmount = 0
+        cumulativeAmount = 0,
+        cost = 0,
+        sale = 0
       } = val ?? {}
 
       const tradesBySymbol = trades.filter((t) => t.symbol === symbol)
@@ -348,6 +359,8 @@ class WeightedAveragesReport {
         sellingWeightedPrice,
         sellingAmount,
         cumulativeAmount,
+        cost,
+        sale,
         firstTradeMts,
         lastTradeMts
       }


### PR DESCRIPTION
This PR removes `cumulativeWeightedPrice` field and adds `cost`/`sale` columns to the weighted averages report

---

Basic changes:
- Removes cumulative weighted price
- Adds `cost` and `sale` columns to the weighted averages report:
  ```js
  Cost: buying_weighted_price * buying_amount
  Sale: selling_weighted_price * selling_amount
  ```
- Changes weighted averages report csv field order:
![Screenshot from 2023-07-25 13-07-08](https://github.com/bitfinexcom/bfx-report/assets/16489235/b6c88fac-e8cc-4778-a226-2d9d698ff50a)

---

Response example:
```jsonc
{
  "jsonrpc": "2.0",
  "result": {
      "nextPage": false,
      "res": [
          {
              "symbol": "tBTCUSD",
              "buyingWeightedPrice": 25163.76585333,
              "buyingAmount": 552.97181669,
              "sellingWeightedPrice": 25157.45514297,
              "sellingAmount": -552.97181669,
              "cumulativeAmount": 0,
              "cost": 13914853.318677677,
              "sale": -13911363.673705304,
              "firstTradeMts": 1627704333998,
              "lastTradeMts": 1690223080583
          }
      ]
  },
  "id": null
}
```
