### PR TITLE
Fix start timestamp to be at least 2013

### DIFF
--- a/workers/loc.api/helpers/date-param.helpers.js
+++ b/workers/loc.api/helpers/date-param.helpers.js
@@ -1,19 +1,23 @@
 'use strict'
 
+const { min, max } = require('lodash')
 const moment = require('moment-timezone')
 
-const { getLimitNotMoreThan } = require('./limit-param.helpers')
 const { TimeframeError } = require('../errors')
 
-const getDateNotMoreNow = (date, now = Date.now()) => {
-  return getLimitNotMoreThan(date, now)
+const MIN_START_MTS = Date.UTC(2013)
+
+const getDateNotMoreNow = (mts, now = Date.now()) => {
+  return min([mts, now])
+}
+
+const getDateNotLessMinStart = (mts, minStart = MIN_START_MTS) => {
+  return max([mts, minStart])
 }
 
 const _setDefaultTimeIfNotExist = (args) => {
   args.params.end = getDateNotMoreNow(args.params.end)
-  args.params.start = args.params.start
-    ? args.params.start
-    : 0
+  args.params.start = getDateNotLessMinStart(args.params.start)
 }
 
 const checkTimeLimit = (args) => {
@@ -29,6 +33,9 @@ const checkTimeLimit = (args) => {
 }
 
 module.exports = {
+  MIN_START_MTS,
+
   getDateNotMoreNow,
+  getDateNotLessMinStart,
   checkTimeLimit
 }

--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -12,7 +12,9 @@ const {
   getLimitNotMoreThan
 } = require('./limit-param.helpers')
 const {
+  MIN_START_MTS,
   getDateNotMoreNow,
+  getDateNotLessMinStart,
   checkTimeLimit
 } = require('./date-param.helpers')
 const getTimezoneConf = require('./get-timezone-conf')
@@ -59,7 +61,9 @@ const FOREX_SYMBS = require('./forex.symbs')
 module.exports = {
   getREST,
   getLimitNotMoreThan,
+  MIN_START_MTS,
   getDateNotMoreNow,
+  getDateNotLessMinStart,
   checkParams,
   hasJobInQueueWithStatusBy,
   isAuthError,

--- a/workers/loc.api/helpers/prepare-response/helpers/get-params.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/get-params.js
@@ -2,7 +2,10 @@
 
 const { cloneDeep } = require('lodash')
 
-const { getDateNotMoreNow } = require('../../date-param.helpers')
+const {
+  getDateNotMoreNow,
+  getDateNotLessMinStart
+} = require('../../date-param.helpers')
 const { getMethodLimit } = require('../../limit-param.helpers')
 
 const getParamsMap = require('./get-params-map')
@@ -30,6 +33,7 @@ module.exports = (
   const allParams = {
     ...cloneDeep(params),
     ...getSymbolParams({ apiMethodName, params, symbPropName }),
+    start: getDateNotLessMinStart(params.start),
     end: getDateNotMoreNow(params.end),
     limit: getMethodLimit(limit, apiMethodName)
   }


### PR DESCRIPTION
This PR fixes `start` timestamp to be at least `Date.UTC(2013)` = `1356998400000` ms

---

The issue is the following:
- some restrictions of the bfx-api are changed for `Funding Credits History`
- now if we set `end: Date.now()` and `start: 0` throws `Internal Server Error` from `bfx-rest` side
- it's an issue for the `sync` mode (as we start syncing with `0`) and setting the default value for requests

---

Related to these issues:
- https://github.com/bitfinexcom/bfx-report-electron/issues/232
- https://github.com/bitfinexcom/bfx-report-electron/issues/233
- https://github.com/bitfinexcom/bfx-report-electron/issues/234
