### PR TITLE
Fix bfx api error response

### DIFF
--- a/workers/loc.api/responder/index.js
+++ b/workers/loc.api/responder/index.js
@@ -24,7 +24,7 @@ const JSON_RPC_VERSION = '2.0'
 const _isHtml = (res) => (_htmlRegExp.test(res))
 
 const _findHtmlTitle = (res) => (
-  res?.match(_htmlTitleRegExp).groups?.body ?? 'HTML title not found'
+  res?.match(_htmlTitleRegExp).groups?.body ?? null
 )
 
 const _getBfxApiErrorMetadata = (err) => {
@@ -35,13 +35,13 @@ const _getBfxApiErrorMetadata = (err) => {
   const isHtml = _isHtml(err.response)
   const body = isHtml
     ? _findHtmlTitle(err.response)
-    : err.response ?? 'Response is not abailable'
+    : err.response ?? null
 
   return {
     bfxApiStatus: err.status,
-    bfxApiStatusText: err.statustext ?? 'Status text is not abailable',
-    bfxApiRawBodyCode: err.code ?? 'Code is not abailable',
-    isBfxApiRawBodyResponseHtml: isHtml ? 'Yes' : 'No',
+    bfxApiStatusText: err.statustext ?? null,
+    bfxApiRawBodyCode: err.code ?? null,
+    isBfxApiRawBodyResponseHtml: isHtml,
     bfxApiRawBodyResponse: body
   }
 }
@@ -148,11 +148,20 @@ const _getErrorMetadata = (args, err) => {
   _addStatusMessageToErrorMessage(errWithMetadata)
   const {
     statusCode: code = 500,
-    statusMessage: message = 'Internal Server Error',
+    statusMessage = 'Internal Server Error',
     data = null
   } = errWithMetadata
 
   const bfxApiErrorMessage = _getBfxApiErrorMetadata(err)
+  const bfxApiStatusText = bfxApiErrorMessage?.bfxApiStatusText
+    ? `: ${bfxApiErrorMessage?.bfxApiStatusText}`
+    : ''
+  const bfxApiRawBodyResponse = bfxApiErrorMessage?.bfxApiRawBodyResponse
+    ? `: ${bfxApiErrorMessage?.bfxApiRawBodyResponse}`
+    : ''
+  const message = bfxApiErrorMessage
+    ? `${statusMessage}: BFX API Error${bfxApiStatusText}${bfxApiRawBodyResponse}`
+    : statusMessage
   const extendedData = bfxApiErrorMessage
     ? {
         bfxApiErrorMessage,
@@ -164,7 +173,7 @@ const _getErrorMetadata = (args, err) => {
     errWithMetadata,
     {
       statusCode: code,
-      statusMessage: message,
+      statusMessage,
       data: extendedData
     }
   )


### PR DESCRIPTION
This PR enhances the error message of the `json rpc` response. The idea is to have extra data in case we catch an error from BFX API side and on the UI use a transparent error message  which can contain BFX API error reasons

```js
res?.error?.message
```

instead of proxy whole error object for error representation

---

Earlier we can have the following `json rpc` cases for errors:

- if internal error:
```jsonc 
{
  "jsonrpc": "2.0",
  "error": {
    "code": 500,
    "message": "Internal Server Error",
    "data": null
  },
  "id": null
}
```

- if error came from BFX API:
```jsonc
{
  "jsonrpc": "2.0",
  "error": {
    "code": 500,
    "message": "Internal Server Error",
    "data": {
      "bfxApiErrorMessage": {
        "bfxApiStatus": 500,
        "bfxApiStatusText": "Internal Server Error",
        "bfxApiRawBodyCode": "Code is not available",
        "isBfxApiRawBodyResponseHtml": "No",
        "bfxApiRawBodyResponse": "generic error"
      }
    }
  },
  "id": null
}
```

- if error came from BFX API as HTML:
```jsonc
{
  "jsonrpc": "2.0",
  "error": {
    "code": 403,
    "message": "Forbidden",
    "data": {
      "bfxApiErrorMessage": {
        "bfxApiStatus": 403,
        "bfxApiStatusText": "Forbidden",
        "bfxApiRawBodyCode": "Code is not available",
        "isBfxApiRawBodyResponseHtml": "Yes",
        "bfxApiRawBodyResponse": "Access denied | [api.staging.bitfinex.com](http://api.staging.bitfinex.com/) used Cloudflare to restrict access"
      }
    }
  },
  "id": null
}
```

---

After changes we can have the following `json rpc` cases for errors:

- if error came from BFX API:
```jsonc
{
  "jsonrpc": "2.0",
  "error": {
    "code": 401,
    "message": "Unauthorized: BFX API Error: Internal Server Error: apikey: digest invalid",
    "data": {
      "bfxApiErrorMessage": {
        "bfxApiStatus": 500,
        "bfxApiStatusText": "Internal Server Error",
        "bfxApiRawBodyCode": 10100,
        "isBfxApiRawBodyResponseHtml": false,
        "bfxApiRawBodyResponse": "apikey: digest invalid"
      }
    }
  },
  "id": null
}
```
```jsonc
{
  "jsonrpc": "2.0",
  "error": {
    "code": 500,
    "message": "Internal Server Error: BFX API Error: Internal Server Error: generic error",
    "data": {
      "bfxApiErrorMessage": {
        "bfxApiStatus": 500,
        "bfxApiStatusText": "Internal Server Error",
        "bfxApiRawBodyCode": null,
        "isBfxApiRawBodyResponseHtml": false,
        "bfxApiRawBodyResponse": "generic error"
      }
    }
  },
  "id": null
}
```

- if error came from BFX API as HTML:
```jsonc
{
  "jsonrpc": "2.0",
  "error": {
    "code": 403,
    "message": "Forbidden: BFX API Error: Forbidden: Access denied | [api.staging.bitfinex.com](http://api.staging.bitfinex.com/) used Cloudflare to restrict access",
    "data": {
      "bfxApiErrorMessage": {
        "bfxApiStatus": 403,
        "bfxApiStatusText": "Forbidden",
        "bfxApiRawBodyCode": null,
        "isBfxApiRawBodyResponseHtml": true,
        "bfxApiRawBodyResponse": "Access denied | [api.staging.bitfinex.com](http://api.staging.bitfinex.com/) used Cloudflare to restrict access"
      }
    }
  },
  "id": null
}
```