### PR TITLE
Inform user that platform is marked in maintenance mode

### DIFF
--- a/workers/loc.api/abstract.ws.event.emitter/index.js
+++ b/workers/loc.api/abstract.ws.event.emitter/index.js
@@ -35,6 +35,16 @@ class AbstractWSEventEmitter {
       action
     )
   }
+
+  emitMaintenanceTurnedOn (
+    handler = () => {},
+    action = 'emitMaintenanceTurnedOn'
+  ) {
+    return this.emit(
+      handler,
+      action
+    )
+  }
 }
 
 decorateInjectable(AbstractWSEventEmitter)

--- a/workers/loc.api/abstract.ws.event.emitter/index.js
+++ b/workers/loc.api/abstract.ws.event.emitter/index.js
@@ -45,6 +45,16 @@ class AbstractWSEventEmitter {
       action
     )
   }
+
+  emitMaintenanceTurnedOff (
+    handler = () => {},
+    action = 'emitMaintenanceTurnedOff'
+  ) {
+    return this.emit(
+      handler,
+      action
+    )
+  }
 }
 
 decorateInjectable(AbstractWSEventEmitter)

--- a/workers/loc.api/helpers/api-errors-testers.js
+++ b/workers/loc.api/helpers/api-errors-testers.js
@@ -75,6 +75,11 @@ const isForbiddenError = (err) => {
   return /forbidden/i.test(_getErrorString(err))
 }
 
+// https://docs.bitfinex.com/docs/rest-general
+const isMaintenanceError = (err) => {
+  return /maintenance/i.test(_getErrorString(err))
+}
+
 const isENetError = (err) => (
   isENetUnreachError(err) ||
   isEConnResetError(err) ||
@@ -107,5 +112,6 @@ module.exports = {
   isEProtoError,
   isTempUnavailableError,
   isENetError,
-  isForbiddenError
+  isForbiddenError,
+  isMaintenanceError
 }

--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -37,7 +37,8 @@ const {
   isENotFoundError,
   isESocketTimeoutError,
   isENetError,
-  isForbiddenError
+  isForbiddenError,
+  isMaintenanceError
 } = require('./api-errors-testers')
 const {
   accountCache,
@@ -82,6 +83,7 @@ module.exports = {
   isESocketTimeoutError,
   isENetError,
   isForbiddenError,
+  isMaintenanceError,
   accountCache,
   parseFields,
   parseLoginsExtraDataFields,


### PR DESCRIPTION
This PR informs user that the platform is marked in `maintenance` mode by WS, in the framework mode

---

The idea is the following:
- if an error `["error", 20060, "maintenance"]` https://docs.bitfinex.com/docs/rest-general catches when fetching data from bfx api
- send `emitMaintenanceTurnedOn` event by WS
- also adds `emitMaintenanceTurnedOff` event which will be sent from the framework part in case maintenance mode is turned off
- in UI if the event is gotten show a corresponding message to inform the user that some features are unavailable
