### PR TITLE
Prevent max listeners exceeded warning

### DIFF
--- a/workers/loc.api/generate-csv/csv-writer/helpers/index.js
+++ b/workers/loc.api/generate-csv/csv-writer/helpers/index.js
@@ -1,0 +1,42 @@
+'use strict'
+
+const { pipeline } = require('stream/promises')
+const { stringify } = require('csv')
+
+const streamWriterToOne = async (
+  rStream,
+  wStream,
+  writeFn,
+  opts
+) => {
+  const { end = true } = opts ?? {}
+  const promise = pipeline(rStream, wStream, { end })
+
+  writeFn(rStream)
+  rStream.end()
+
+  await promise
+}
+
+const streamWriter = async (wStream, csvStreamDataMap) => {
+  for (const [i, csvStreamData] of csvStreamDataMap.entries()) {
+    const isLast = (i + 1) === csvStreamDataMap.length
+    const {
+      columnParams,
+      writeFn
+    } = csvStreamData
+
+    const stringifier = stringify(columnParams)
+    await streamWriterToOne(
+      stringifier,
+      wStream,
+      writeFn,
+      { end: isLast }
+    )
+  }
+}
+
+module.exports = {
+  streamWriterToOne,
+  streamWriter
+}

--- a/workers/loc.api/generate-csv/csv.job.data.js
+++ b/workers/loc.api/generate-csv/csv.job.data.js
@@ -1038,7 +1038,7 @@ class CsvJobData {
     uId,
     uInfo
   ) {
-    checkParams(args, 'paramsSchemaForWeightedAveragesReportApiCsv')
+    checkParams(args, 'paramsSchemaForWeightedAveragesReportApiCsv', ['symbol'])
 
     const {
       userId,


### PR DESCRIPTION
This PR fixes `MaxListenersExceededWarning` for complicated `csv` reports using the `transform` csv stream waiting for writing to complete `one by one` instead of pipelining all csv streams `simultaneously`
Also, the corresponding approach aims to use in the framework