### PR TITLE
Remove lodash usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "csv": "5.5.3",
     "inversify": "6.0.1",
     "js-yaml": "4.1.0",
+    "lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git",
     "lodash": "4.17.21",
     "lru": "3.1.0",
     "moment": "2.29.4",

--- a/workers/loc.api/helpers/check-params.js
+++ b/workers/loc.api/helpers/check-params.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { cloneDeep } = require('lodash')
+const { cloneDeep } = require('lib-js-util-base')
 const Ajv = require('ajv')
 
 const schema = require('./schema')

--- a/workers/loc.api/helpers/date-param.helpers.js
+++ b/workers/loc.api/helpers/date-param.helpers.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { min, max } = require('lodash')
 const moment = require('moment-timezone')
 
 const { TimeframeError } = require('../errors')
@@ -8,11 +7,19 @@ const { TimeframeError } = require('../errors')
 const MIN_START_MTS = Date.UTC(2013)
 
 const getDateNotMoreNow = (mts, now = Date.now()) => {
-  return min([mts, now])
+  if (!Number.isFinite(mts)) {
+    return now
+  }
+
+  return Math.min(mts, now)
 }
 
 const getDateNotLessMinStart = (mts, minStart = MIN_START_MTS) => {
-  return max([mts, minStart])
+  if (!Number.isFinite(mts)) {
+    return minStart
+  }
+
+  return Math.max(mts, minStart)
 }
 
 const _setDefaultTimeIfNotExist = (args) => {

--- a/workers/loc.api/helpers/get-data-from-api.js
+++ b/workers/loc.api/helpers/get-data-from-api.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { cloneDeep } = require('lodash')
+const { cloneDeep } = require('lib-js-util-base')
 
 const Interrupter = require('../interrupter')
 const AbstractWSEventEmitter = require('../abstract.ws.event.emitter')

--- a/workers/loc.api/helpers/normalize-filter-params.js
+++ b/workers/loc.api/helpers/normalize-filter-params.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { cloneDeep } = require('lodash')
+const { cloneDeep } = require('lib-js-util-base')
 
 const FILTER_MODELS_NAMES = require('./filter.models.names')
 const FILTER_CONDITIONS = require('./filter.conditions')

--- a/workers/loc.api/helpers/prepare-response/helpers/get-params.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/get-params.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { cloneDeep } = require('lodash')
+const { cloneDeep } = require('lib-js-util-base')
 
 const {
   getDateNotMoreNow,

--- a/workers/loc.api/helpers/prepare-response/helpers/omit-private-model-fields.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/omit-private-model-fields.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { omit } = require('lodash')
+const { omit } = require('lib-js-util-base')
 
 const OMITTING_FIELDS = [
   '_events',

--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { cloneDeep } = require('lodash')
+const { cloneDeep } = require('lib-js-util-base')
 
 const _publicTradesSymbol = {
   type: ['string', 'array'],

--- a/workers/loc.api/queue/processor.js
+++ b/workers/loc.api/queue/processor.js
@@ -1,9 +1,9 @@
 'use strict'
 
 const {
-  omit
+  omit,
+  cloneDeep
 } = require('lib-js-util-base')
-const { cloneDeep } = require('lodash')
 const { promisify } = require('util')
 const { pipeline } = require('stream')
 const fs = require('fs')

--- a/workers/loc.api/queue/processor.js
+++ b/workers/loc.api/queue/processor.js
@@ -1,9 +1,9 @@
 'use strict'
 
 const {
-  omit,
-  cloneDeep
-} = require('lodash')
+  omit
+} = require('lib-js-util-base')
+const { cloneDeep } = require('lodash')
 const { promisify } = require('util')
 const { pipeline } = require('stream')
 const fs = require('fs')

--- a/workers/loc.api/queue/write-data-to-stream/data-normalizer.js
+++ b/workers/loc.api/queue/write-data-to-stream/data-normalizer.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { cloneDeep } = require('lodash')
+const { cloneDeep } = require('lib-js-util-base')
 
 const { splitSymbolPairs } = require('../../helpers')
 

--- a/workers/loc.api/queue/write-data-to-stream/helpers.js
+++ b/workers/loc.api/queue/write-data-to-stream/helpers.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { cloneDeep } = require('lodash')
+const { cloneDeep } = require('lib-js-util-base')
 const moment = require('moment-timezone')
 
 const dataNormalizer = require('./data-normalizer')

--- a/workers/loc.api/queue/write-data-to-stream/index.js
+++ b/workers/loc.api/queue/write-data-to-stream/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { cloneDeep } = require('lodash')
+const { cloneDeep } = require('lib-js-util-base')
 
 const {
   writeMessageToStream,


### PR DESCRIPTION
This PR removes lodash `omit`, `cloneDeep`, `min`, `max` usage. It's the next part of the migration from the `lodash` lib to bfx internal one