### PR TITLE
Add test runner and report to GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+run-name: 'Run tests: Commit ${{ github.sha }}'
+
+on:
+  pull_request:
+    types: [opened, reopened, edited]
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  linux-test-runner:
+    name: Linux Test Runner
+    timeout-minutes: 30
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18.17.1
+    - name: Setup configs
+      run: |
+        cp config/common.json.example config/common.json \
+          && cp config/service.report.json.example config/service.report.json \
+          && cp config/facs/grc.config.json.example config/facs/grc.config.json \
+          && cp config/facs/grc-slack.config.json.example config/facs/grc-slack.config.json
+    - name: Install deps
+      run: npm i
+    - name: Run tests
+      run: npm test -- --reporter=json --reporter-option output=test-report.json
+    - uses: actions/upload-artifact@v3
+      if: success() || failure()
+      with:
+        name: test-results
+        path: test-report.json

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,23 @@
+name: 'Test Report'
+
+on:
+  workflow_run:
+    workflows: ['CI']
+    types:
+      - completed
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  report:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: dorny/test-reporter@v1
+      with:
+        artifact: test-results
+        name: Test Report
+        path: test-report.json
+        reporter: mocha-json

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,4 +1,5 @@
 name: 'Test Report'
+run-name: 'Test Report: Commit ${{ github.sha }}'
 
 on:
   workflow_run:
@@ -12,12 +13,18 @@ permissions:
   checks: write
 
 jobs:
-  report:
+  web-page-report:
+    name: Web Page Report
     runs-on: ubuntu-22.04
     steps:
     - uses: dorny/test-reporter@v1
+      id: test-results
       with:
         artifact: test-results
-        name: Test Report
+        name: Mocha Tests
         path: test-report.json
         reporter: mocha-json
+    - name: Test Report Summary
+      run: |
+        echo "### Test Report page is ready! :rocket:" >> $GITHUB_STEP_SUMMARY
+        echo "And available at the following [Link](${{ steps.test-results.outputs.url_html }})" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This PR adds test runner and report workflows to GitHub actions

---

Report examples of test:
- successful: https://github.com/ZIMkaRU/bfx-report/pull/2/checks?check_run_id=17529429034
- failed: https://github.com/ZIMkaRU/bfx-report/runs/17528440663