### PR TITLE
Remove lodash usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "inversify": "6.0.1",
     "js-yaml": "4.1.0",
     "lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git",
-    "lodash": "4.17.21",
     "lru": "3.1.0",
     "moment": "2.29.4",
     "moment-timezone": "0.5.39",

--- a/workers/loc.api/generate-csv/index.js
+++ b/workers/loc.api/generate-csv/index.js
@@ -1,11 +1,6 @@
 'use strict'
 
 const {
-  upperFirst,
-  lowerFirst
-} = require('lodash')
-
-const {
   checkFilterParams,
   FILTER_MODELS_NAMES,
   normalizeFilterParams
@@ -58,7 +53,8 @@ const _getCsvStoreStatus = async ({
 
 const _filterModelNameMap = Object.values(FILTER_MODELS_NAMES)
   .reduce((map, name) => {
-    const key = `get${upperFirst(name)}CsvJobData`
+    const baseName = `${name[0].toUpperCase()}${name.slice(1)}`
+    const key = `get${baseName}CsvJobData`
 
     map.set(key, name)
 
@@ -74,7 +70,7 @@ const _truncateCsvNameEnding = (name) => {
     .replace(/^get/i, '')
     .replace(/csv$/i, '')
 
-  return lowerFirst(cleanedName)
+  return `${cleanedName[0].toLowerCase()}${cleanedName.slice(1)}`
 }
 
 const _getFilterModelNamesAndArgs = (

--- a/workers/loc.api/helpers/prepare-response/helpers/get-symbol-params.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/get-symbol-params.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { isEmpty } = require('lodash')
+const { isEmpty } = require('lib-js-util-base')
 
 const {
   LedgerPaymentFilteringParamsError

--- a/workers/loc.api/queue/helpers/get-complete-file-name.js
+++ b/workers/loc.api/queue/helpers/get-complete-file-name.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { snakeCase } = require('lodash')
 const { v4: uuidv4 } = require('uuid')
 
 const _fileNamesMap = new Map([
@@ -67,10 +66,15 @@ const _getBaseName = (
   if (isMultiExport) {
     return 'multiple-exports'
   }
+  if (namesMap.has(queueName)) {
+    return namesMap.get(queueName)
+  }
 
-  return namesMap.has(queueName)
-    ? namesMap.get(queueName)
-    : snakeCase(queueName.replace(/^get/, ''))
+  return queueName
+    .replace(/^get/, '')
+    .replace(/[A-Z]/g, (match, offset) => (
+      `${offset > 0 ? '_' : ''}${match.toLowerCase()}`
+    ))
 }
 
 const _getDateString = mc => {


### PR DESCRIPTION
This PR removes lodash `lowerFirs`, `upperFirs`, `snakeCase` util usage and uses `isEmpty` util from the `lib-js-util-base`. It's the last part of the removal of the `lodash` lib