### PR TITLE
Fix double requests while syncing candles

### DIFF
--- a/workers/loc.api/helpers/prepare-response/helpers/is-not-contained-same-mts.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/is-not-contained-same-mts.js
@@ -27,7 +27,7 @@ module.exports = (args, opts) => {
   )
 
   return (
-    apiRes.length === 0 ||
+    apiRes.length <= 1 || // Check makes sense to prevent double requests to api
     methodLimit > limit ||
     apiRes.some((item) => (
       item?.[datePropName] !== mts


### PR DESCRIPTION
This PR fixes double requests while syncing `candles`

---

The issue is: when we sync data in the framework mode, candles request can give only one item, in this case, we shouldn't process the part of logic with handling of containing the same timestamps in all items