### PR TITLE
Add detection for bfx auth error

### DIFF
--- a/workers/loc.api/helpers/api-errors-testers.js
+++ b/workers/loc.api/helpers/api-errors-testers.js
@@ -8,7 +8,7 @@ const _getErrorString = (err) => {
 }
 
 const isAuthError = (err) => {
-  return /(token: invalid)|(missing api key or secret)|(apikey: digest invalid)|(apikey: invalid)|(ERR_AUTH_UNAUTHORIZED)|(ERR_AUTH_API: ERR_INVALID_CREDENTIALS)/i.test(_getErrorString(err))
+  return /(token: invalid)|(missing api key or secret)|(apikey: digest invalid)|(apikey: invalid)|(ERR_AUTH_UNAUTHORIZED)|(ERR_AUTH_API)/i.test(_getErrorString(err))
 }
 
 const isRateLimitError = (err) => {


### PR DESCRIPTION
This PR adds detection for BFX auth error

---

There can be cases with getting `ERR_AUTH_API: ERR_TOKEN_ALREADY_USED` error from the BFX API side
We have several issues with the same error:
- https://github.com/bitfinexcom/bfx-report-electron/issues/281
- https://github.com/bitfinexcom/bfx-report-electron/issues/313

It should be detected as an auth error and processed with `401` instead `500` at least do not show a bug report modal window in the electron app. And these changes are enough to cover it

---

On the other hand, the mentioned issue related to 2fa:
- when need to set google auth code
- UI doesn't block btn after the first push
- and the user can make 2 requests accidentally
- and for auth token generation will be used otp token 2 times
- as a result `ERR_AUTH_API: ERR_TOKEN_ALREADY_USED` error
