### PR TITLE
Move statement details section under logo for pdf reports

### DIFF
--- a/workers/loc.api/generate-report-file/pdf-writer/index.js
+++ b/workers/loc.api/generate-report-file/pdf-writer/index.js
@@ -110,6 +110,8 @@ class PdfWriter {
       template: 'No data',
       format: 'portrait',
       orientation: 'Letter',
+      headerHeight: '70mm',
+      footerHeight: '28mm',
       ...args
     }
 

--- a/workers/loc.api/generate-report-file/pdf-writer/index.js
+++ b/workers/loc.api/generate-report-file/pdf-writer/index.js
@@ -110,7 +110,7 @@ class PdfWriter {
       template: 'No data',
       format: 'portrait',
       orientation: 'Letter',
-      headerHeight: '54mm',
+      headerHeight: '65mm',
       footerHeight: '28mm',
       ...args
     }

--- a/workers/loc.api/generate-report-file/pdf-writer/index.js
+++ b/workers/loc.api/generate-report-file/pdf-writer/index.js
@@ -110,7 +110,7 @@ class PdfWriter {
       template: 'No data',
       format: 'portrait',
       orientation: 'Letter',
-      headerHeight: '70mm',
+      headerHeight: '54mm',
       footerHeight: '28mm',
       ...args
     }

--- a/workers/loc.api/generate-report-file/pdf-writer/templates/base.pug
+++ b/workers/loc.api/generate-report-file/pdf-writer/templates/base.pug
@@ -40,7 +40,7 @@ html(lang=language)
       - const username = jobData.userInfo.username ?? email.replace(/@.*/, '') ?? ''
 
       .content.statement-details-content
-        ul.responsive-table.sm.width-by-content
+        ul.responsive-table.width-by-content
           li.table-header
             .col
               :translate(prop='template.statementDetails')

--- a/workers/loc.api/generate-report-file/pdf-writer/templates/style.css
+++ b/workers/loc.api/generate-report-file/pdf-writer/templates/style.css
@@ -287,7 +287,7 @@ h6 {
 
 .statement-details-content {
   position: absolute;
-  top: 60px;
+  top: 40px;
   left: 0;
   line-height: 1;
   margin-bottom: 0;
@@ -311,7 +311,7 @@ h6 {
 
 /* Uses `mm` for height to support default settings of `html-pdf` lib */
 .header-space, .header {
-  height: 70mm;
+  height: 54mm;
 }
 
 .footer-space, .footer {

--- a/workers/loc.api/generate-report-file/pdf-writer/templates/style.css
+++ b/workers/loc.api/generate-report-file/pdf-writer/templates/style.css
@@ -164,6 +164,20 @@ h6 {
   color: #3e4444;
 }
 
+/*
+  The fix for Phantomjs rendering
+*/
+.common-content-header {
+  border-width: 1px;
+  border-color: rgba(255, 255, 255, 0);
+  border-top-style: solid;
+  border-bottom-style: solid;
+}
+
+.no-phantomjs .common-content-header {
+  border: 0;
+}
+
 .responsive-table {
   margin-bottom: 20px;
 }

--- a/workers/loc.api/generate-report-file/pdf-writer/templates/style.css
+++ b/workers/loc.api/generate-report-file/pdf-writer/templates/style.css
@@ -287,7 +287,7 @@ h6 {
 
 .statement-details-content {
   position: absolute;
-  top: 40px;
+  top: 50px;
   left: 0;
   line-height: 1;
   margin-bottom: 0;
@@ -311,7 +311,7 @@ h6 {
 
 /* Uses `mm` for height to support default settings of `html-pdf` lib */
 .header-space, .header {
-  height: 54mm;
+  height: 65mm;
 }
 
 .footer-space, .footer {

--- a/workers/loc.api/generate-report-file/pdf-writer/templates/style.css
+++ b/workers/loc.api/generate-report-file/pdf-writer/templates/style.css
@@ -40,7 +40,6 @@ html, body {
   box-sizing: border-box;
 }
 
-
 html {
   line-height: 1;
 }
@@ -52,11 +51,7 @@ body {
 html, body, .header, .footer {
   font-family: "Inter", sans-serif;
   font-weight: 400;
-  font-size: 8px;
-}
-
-.sm {
-  font-size: 5px;
+  font-size: 11px;
 }
 
 h1 {
@@ -292,8 +287,8 @@ h6 {
 
 .statement-details-content {
   position: absolute;
-  top: 11px;
-  right: 0;
+  top: 60px;
+  left: 0;
   line-height: 1;
   margin-bottom: 0;
 }
@@ -316,7 +311,7 @@ h6 {
 
 /* Uses `mm` for height to support default settings of `html-pdf` lib */
 .header-space, .header {
-  height: 43.5mm;
+  height: 70mm;
 }
 
 .footer-space, .footer {


### PR DESCRIPTION
This PR moves the `Statement Details` section under the logo for pdf reports

---

![S-D-2](https://github.com/bitfinexcom/bfx-report/assets/16489235/89b9c4d0-a8ff-48ab-acfa-5e4797772f39)

![S-D-1](https://github.com/bitfinexcom/bfx-report/assets/16489235/e2c477af-f443-4c26-8982-de1ea1adf914)

---

**Depends** on this PR:
- https://github.com/bitfinexcom/bfx-ext-pdf-js/pull/4
