### PR TITLE
Set 90sec timeout for grc requests

### DIFF
--- a/workers/loc.api/helpers/grc-bfx-req.js
+++ b/workers/loc.api/helpers/grc-bfx-req.js
@@ -6,7 +6,7 @@ module.exports = (
   service,
   action,
   args = [],
-  timeout = 10000
+  timeout = 90000
 } = {}) => {
   return new Promise((resolve, reject) => {
     rService.ctx.grc_bfx.req(


### PR DESCRIPTION
This PR sets `90sec` timeout for grc requests to have the same timeout as for api requests