### PR TITLE
Handle unexpected BFX API errors

### DIFF
--- a/workers/loc.api/helpers/get-data-from-api.js
+++ b/workers/loc.api/helpers/get-data-from-api.js
@@ -69,6 +69,7 @@ module.exports = (
   let countNetError = 0
   let countRateLimitError = 0
   let countNonceSmallError = 0
+  let countUnexpectedError = 0
   let res = null
 
   while (true) {
@@ -157,7 +158,17 @@ module.exports = (
         continue
       }
 
-      throw err
+      // Handle unexpected BFX API errors
+      countUnexpectedError += 1
+
+      if (countUnexpectedError > 3) {
+        throw err
+      }
+      if (_isInterrupted(_interrupter)) {
+        return { isInterrupted: true }
+      }
+
+      await _delay(10000, _interrupter)
     }
   }
 


### PR DESCRIPTION
This PR adds handling unexpected BFX API errors

---

Adds `3` retries with a timeout `10sec` if catches any unexpected errors during report generation or db sync in framework mode

---

**Related** to these issues:
- https://github.com/bitfinexcom/bfx-report-electron/issues/355
- https://github.com/bitfinexcom/bfx-report-electron/issues/354

