### PR TITLE
Increase inner limit for bfx api trades symbol hist endpoint

### DIFF
--- a/workers/loc.api/helpers/limit-param.helpers.js
+++ b/workers/loc.api/helpers/limit-param.helpers.js
@@ -9,7 +9,7 @@ const getMethodLimit = (sendLimit, method, methodsLimits = {}) => {
     trades: { default: 500, max: 1000, innerMax: 2500 },
     orderTrades: { default: 500, max: 1000, innerMax: 1000 },
     fundingTrades: { default: 500, max: 1000, innerMax: 1000 },
-    publicTrades: { default: 500, max: 5000, innerMax: 5000 },
+    publicTrades: { default: 500, max: 5000, innerMax: 10000 },
     orders: { default: 250, max: 500, innerMax: 2500 },
     movements: { default: 25, max: 25, innerMax: 1000 },
     fundingOfferHistory: { default: 100, max: 500, innerMax: 500 },


### PR DESCRIPTION
This PR increases the inner `limit` for the BFX API [trades/{symbol}/hist](https://docs.bitfinex.com/reference/rest-public-trades) endpoint. It's useful for the `Transaction Tax Report` in case of currency conversion to USD to reduce the amount of calls and help users to go through `Rate Limit`