### PR TITLE
Add dependabot config and update pug

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    target-branch: "staging"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+      time: "00:00"
+      timezone: "Etc/UTC"
+    commit-message:
+      prefix: "[npm] "
+    labels:
+      - "npm"
+      - "dependencies"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lru": "3.1.0",
     "moment": "2.29.4",
     "moment-timezone": "0.5.39",
-    "pug": "3.0.2",
+    "pug": "3.0.3",
     "reflect-metadata": "0.1.13",
     "triple-beam": "1.3.0",
     "uuid": "9.0.0",


### PR DESCRIPTION
This PR adds `dependabot` config for the ability to open new PRs against the `staging` branch
Also bumps `pug` version to `3.0.3` to resolve this PR:
- https://github.com/bitfinexcom/bfx-report/pull/376
There is a security improvement https://github.com/pugjs/pug/pull/3438