### PR TITLE
Add csv formatter for tax report source field

### DIFF
--- a/workers/loc.api/queue/write-data-to-stream/helpers.js
+++ b/workers/loc.api/queue/write-data-to-stream/helpers.js
@@ -80,6 +80,22 @@ const _formatters = {
     }
 
     return msg
+  },
+  lowerCaseWithUpperFirst: (str) => {
+    if (
+      !str ||
+      typeof str !== 'string' ||
+      str.length < 2
+    ) {
+      return str
+    }
+
+    const lower = str.toLowerCase()
+    const normalized = lower.replace(/_/g, ' ')
+    const head = normalized[0].toUpperCase()
+    const tail = normalized.slice(1)
+
+    return `${head}${tail}`
   }
 }
 


### PR DESCRIPTION
This PR adds `CSV`/`PDF` formatter for the tax report `source` field to follow the UI view, eg show `AIRDROP_ON_WALLET` as `Airdrop on wallet`