### PR TITLE
Add socket hang up error processing

### DIFF
--- a/workers/loc.api/helpers/api-errors-testers.js
+++ b/workers/loc.api/helpers/api-errors-testers.js
@@ -83,6 +83,10 @@ const isDNSAvailabilityError = (err) => {
   return /ERR_NAME_NOT_RESOLVED/i.test(_getErrorString(err))
 }
 
+const isSocketHangUpError = (err) => {
+  return /socket hang up/i.test(_getErrorString(err))
+}
+
 const isForbiddenError = (err) => {
   return /forbidden/i.test(_getErrorString(err))
 }
@@ -106,7 +110,8 @@ const isENetError = (err) => (
   isEProtoError(err) ||
   isTempUnavailableError(err) ||
   isBadGatewayError(err) ||
-  isDNSAvailabilityError(err)
+  isDNSAvailabilityError(err) ||
+  isSocketHangUpError(err)
 )
 
 module.exports = {
@@ -129,6 +134,7 @@ module.exports = {
   isTempUnavailableError,
   isBadGatewayError,
   isDNSAvailabilityError,
+  isSocketHangUpError,
   isENetError,
   isForbiddenError,
   isMaintenanceError

--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -42,6 +42,7 @@ const {
   isTempUnavailableError,
   isBadGatewayError,
   isDNSAvailabilityError,
+  isSocketHangUpError,
   isENetError,
   isForbiddenError,
   isMaintenanceError
@@ -95,6 +96,7 @@ module.exports = {
   isTempUnavailableError,
   isBadGatewayError,
   isDNSAvailabilityError,
+  isSocketHangUpError,
   isENetError,
   isForbiddenError,
   isMaintenanceError,


### PR DESCRIPTION
This PR adds `socket hang up` error processing as `ENet` error

---

Related to this issue:
- https://github.com/bitfinexcom/bfx-report-electron/issues/400

