### PR TITLE
Add common net error processing

### DIFF
--- a/workers/loc.api/helpers/api-errors-testers.js
+++ b/workers/loc.api/helpers/api-errors-testers.js
@@ -87,6 +87,10 @@ const isSocketHangUpError = (err) => {
   return /socket hang up/i.test(_getErrorString(err))
 }
 
+const isCommonNetError = (err) => {
+  return /net::ERR_/i.test(_getErrorString(err))
+}
+
 const isForbiddenError = (err) => {
   return /forbidden/i.test(_getErrorString(err))
 }
@@ -111,7 +115,8 @@ const isENetError = (err) => (
   isTempUnavailableError(err) ||
   isBadGatewayError(err) ||
   isDNSAvailabilityError(err) ||
-  isSocketHangUpError(err)
+  isSocketHangUpError(err) ||
+  isCommonNetError(err)
 )
 
 module.exports = {
@@ -135,6 +140,7 @@ module.exports = {
   isBadGatewayError,
   isDNSAvailabilityError,
   isSocketHangUpError,
+  isCommonNetError,
   isENetError,
   isForbiddenError,
   isMaintenanceError

--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -43,6 +43,7 @@ const {
   isBadGatewayError,
   isDNSAvailabilityError,
   isSocketHangUpError,
+  isCommonNetError,
   isENetError,
   isForbiddenError,
   isMaintenanceError
@@ -97,6 +98,7 @@ module.exports = {
   isBadGatewayError,
   isDNSAvailabilityError,
   isSocketHangUpError,
+  isCommonNetError,
   isENetError,
   isForbiddenError,
   isMaintenanceError,


### PR DESCRIPTION
This PR adds common net `net::ERR_` error processing as `ENet` error

---

Related to these issues:
- https://github.com/bitfinexcom/bfx-report-electron/issues/383
- https://github.com/bitfinexcom/bfx-report-electron/issues/362
