### PR TITLE
Fix node-fetch timeout error processing

### DIFF
--- a/workers/loc.api/helpers/api-errors-testers.js
+++ b/workers/loc.api/helpers/api-errors-testers.js
@@ -40,7 +40,7 @@ const isETimedOutError = (err) => {
 }
 
 const isNodeFetchTimeoutError = (err) => {
-  return /network timeout/i.test(_getErrorString(err))
+  return /timeout/i.test(_getErrorString(err))
 }
 
 const isEAiAgainError = (err) => {


### PR DESCRIPTION
This PR fixes `node-fetch` timeout error processing for slow network connection

---

![Screenshot 2024-09-02 at 15 54 25](https://github.com/user-attachments/assets/f3285ead-8573-4a8d-83aa-3880b42477b9)
