### PR TITLE
Remove language schema param check and add en fallback lng

### DIFF
--- a/workers/loc.api/helpers/schema.js
+++ b/workers/loc.api/helpers/schema.js
@@ -56,23 +56,7 @@ const dateFormat = {
     'YYYY-MM-DD'
   ]
 }
-const language = {
-  type: 'string',
-  enum: [
-    'en',
-    'en-US',
-    'ru',
-    'zh-CN',
-    'zh-TW',
-    'tr',
-    'tr-TR',
-    'es',
-    'es-EM',
-    'pt',
-    'pt-PT',
-    'pt-BR'
-  ]
-}
+const language = { type: 'string' }
 
 const paramsSchemaForPayInvoiceList = {
   ...paramsSchemaForApi,

--- a/workers/loc.api/i18next/index.js
+++ b/workers/loc.api/i18next/index.js
@@ -23,9 +23,9 @@ module.exports = (params) => {
   const configs = merge(
     {
       fallbackLng: {
-        es: ['es-EM'],
-        pt: ['pt-BR'],
-        zh: ['zh-CN'],
+        es: ['es-EM', 'en'],
+        pt: ['pt-BR', 'en'],
+        zh: ['zh-CN', 'en'],
         default: ['en']
       },
       ns: Object.values(TRANSLATION_NAMESPACES),


### PR DESCRIPTION
This PR removes `language` schema param check and adds `en` fallback language to prevent returning the translation key `key.nestedKey.etc` if a value is missing for a certain language and adds the ability to try to take one from the default `en` translation file as it was done in the electron app https://github.com/bitfinexcom/bfx-report-electron/pull/426