### PR TITLE
Migrate from html-pdf to puppeteer for pdf creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         submodules: recursive
     - uses: actions/setup-node@v4
       with:
-        node-version: 18.17.1
+        node-version: 20.18.1
     - name: Setup configs
       run: |
         cp config/common.json.example config/common.json \

--- a/workers/loc.api/generate-report-file/pdf-writer/index.js
+++ b/workers/loc.api/generate-report-file/pdf-writer/index.js
@@ -52,6 +52,10 @@ class PdfWriter {
     this.i18next = i18next
 
     this.isElectronjsEnv = false
+    this.shouldZoomBeAdjusted = (
+      process.platform !== 'win32' &&
+      !this.isElectronjsEnv
+    )
 
     this.addTemplates()
     this.compileTemplate()
@@ -174,7 +178,7 @@ class PdfWriter {
     const reportColumns = jobData?.columnsPdf ?? jobData?.columnsCsv
 
     const html = template({
-      isElectronjsEnv: this.isElectronjsEnv,
+      shouldZoomBeAdjusted: this.shouldZoomBeAdjusted,
       apiData,
       jobData,
       reportColumns,

--- a/workers/loc.api/generate-report-file/pdf-writer/index.js
+++ b/workers/loc.api/generate-report-file/pdf-writer/index.js
@@ -101,7 +101,10 @@ class PdfWriter {
       apiData,
       opts
     )
-    const buffer = await this.createPDFBuffer({ template })
+    const buffer = await this.createPDFBuffer({
+      template,
+      language: opts?.language
+    })
 
     return buffer
   }
@@ -192,7 +195,7 @@ class PdfWriter {
     return html
   }
 
-  #getTranslator (language) {
+  getTranslator (language) {
     return getTranslator(
       { i18next: this.i18next },
       {
@@ -248,7 +251,7 @@ class PdfWriter {
     const languages = this.#getAvailableLanguages()
 
     for (const language of languages) {
-      const translate = this.#getTranslator(language)
+      const translate = this.getTranslator(language)
 
       for (const [templateFileName, templatePath] of this.#templatePaths) {
         const fn = pug.compileFile(templatePath, {

--- a/workers/loc.api/generate-report-file/pdf-writer/templates/base.pug
+++ b/workers/loc.api/generate-report-file/pdf-writer/templates/base.pug
@@ -13,7 +13,7 @@ html(lang=language)
     //- https://github.com/marcbachmann/node-html-pdf/issues/619
     //- https://github.com/marcbachmann/node-html-pdf/issues/525
     //- ratio for rendering: 72dpi (pdf) / 96dpi (browser), 72/96 = 0.75
-    if process.platform !== 'win32' && !isElectronjsEnv
+    if shouldZoomBeAdjusted
       style @media print { html { zoom: 0.75; } }
       style @media print { .header, .footer { zoom: 1; } }
     else


### PR DESCRIPTION
This PR migrates from `html-pdf` to `puppeteer` for pdf creation as the first one repo is not maintained anymore. Adds minor changes for the framework mode