### PR TITLE
Add backoff and jitter for bfx-api requests

### DIFF
--- a/workers/loc.api/helpers/get-data-from-api/helpers/calc-back-off-and-jittered-delay.js
+++ b/workers/loc.api/helpers/get-data-from-api/helpers/calc-back-off-and-jittered-delay.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const getRandomInt = require('./get-random-int')
+
+/**
+ * Decorrelated Jitter implementation
+ * https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+ */
+module.exports = (opts) => {
+  const {
+    startingDelayMs = 80 * 1_000,
+    maxDelayMs = 5 * 60 * 1_000,
+    timeMultiple = 1.3,
+    prevBackOffDelayMs = 0,
+    numOfDelayedAttempts = 1
+  } = opts ?? {}
+
+  const startingDelayShifterMs = 5_000 * numOfDelayedAttempts
+  const _startingDelayMs = startingDelayMs + startingDelayShifterMs
+  const calcedDelay = prevBackOffDelayMs * timeMultiple
+
+  if (calcedDelay < _startingDelayMs) {
+    return startingDelayMs
+  }
+
+  const jitteredDelay = getRandomInt(_startingDelayMs, calcedDelay)
+  const limitedDelay = Math.min(maxDelayMs, jitteredDelay)
+
+  return limitedDelay
+}

--- a/workers/loc.api/helpers/get-data-from-api/helpers/calc-back-off-and-jittered-delay.js
+++ b/workers/loc.api/helpers/get-data-from-api/helpers/calc-back-off-and-jittered-delay.js
@@ -10,20 +10,17 @@ module.exports = (opts) => {
   const {
     startingDelayMs = 80 * 1_000,
     maxDelayMs = 5 * 60 * 1_000,
-    timeMultiple = 1.3,
-    prevBackOffDelayMs = 0,
-    numOfDelayedAttempts = 1
+    startingTimeMultiplier = 1.2,
+    endingTimeMultiplier = 1.5,
+    prevBackOffDelayMs = 0
   } = opts ?? {}
 
-  const startingDelayShifterMs = 5_000 * numOfDelayedAttempts
-  const _startingDelayMs = startingDelayMs + startingDelayShifterMs
-  const calcedDelay = prevBackOffDelayMs * timeMultiple
+  const prevDelayNotLessStarting = Math.max(startingDelayMs, prevBackOffDelayMs)
 
-  if (calcedDelay < _startingDelayMs) {
-    return startingDelayMs
-  }
+  const calcedStar = prevDelayNotLessStarting * startingTimeMultiplier
+  const calcedEnd = prevDelayNotLessStarting * endingTimeMultiplier
 
-  const jitteredDelay = getRandomInt(_startingDelayMs, calcedDelay)
+  const jitteredDelay = getRandomInt(calcedStar, calcedEnd)
   const limitedDelay = Math.min(maxDelayMs, jitteredDelay)
 
   return limitedDelay

--- a/workers/loc.api/helpers/get-data-from-api/helpers/delay.js
+++ b/workers/loc.api/helpers/get-data-from-api/helpers/delay.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const Interrupter = require('../../../interrupter')
+const isInterrupted = require('./is-interrupted')
+
+module.exports = (mc = 80000, interrupter) => {
+  if (isInterrupted(interrupter)) {
+    return Promise.resolve({ isInterrupted: true })
+  }
+
+  return new Promise((resolve) => {
+    const hasInterrupter = interrupter instanceof Interrupter
+    const timeout = setTimeout(() => {
+      if (hasInterrupter) {
+        interrupter.offInterrupt(onceInterruptHandler)
+      }
+
+      resolve({ isInterrupted: false })
+    }, mc)
+    const onceInterruptHandler = () => {
+      if (!timeout.hasRef()) {
+        return
+      }
+
+      clearTimeout(timeout)
+      resolve({ isInterrupted: true })
+    }
+
+    if (hasInterrupter) {
+      interrupter.onceInterrupt(onceInterruptHandler)
+    }
+  })
+}

--- a/workers/loc.api/helpers/get-data-from-api/helpers/get-empty-arr-res.js
+++ b/workers/loc.api/helpers/get-data-from-api/helpers/get-empty-arr-res.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = () => {
+  return { jsonrpc: '2.0', result: [], id: null }
+}

--- a/workers/loc.api/helpers/get-data-from-api/helpers/get-random-int.js
+++ b/workers/loc.api/helpers/get-data-from-api/helpers/get-random-int.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = (min, max) => {
+  const minCeiled = Math.ceil(min)
+  const maxFloored = Math.floor(max)
+
+  return Math.floor(Math.random() * (maxFloored - minCeiled) + minCeiled)
+}

--- a/workers/loc.api/helpers/get-data-from-api/helpers/index.js
+++ b/workers/loc.api/helpers/get-data-from-api/helpers/index.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const getRandomInt = require('./get-random-int')
+const calcBackOffAndJitteredDelay = require(
+  './calc-back-off-and-jittered-delay'
+)
+const delay = require('./delay')
+const isInterrupted = require('./is-interrupted')
+const getEmptyArrRes = require('./get-empty-arr-res')
+
+module.exports = {
+  getRandomInt,
+  calcBackOffAndJitteredDelay,
+  delay,
+  isInterrupted,
+  getEmptyArrRes
+}

--- a/workers/loc.api/helpers/get-data-from-api/helpers/is-interrupted.js
+++ b/workers/loc.api/helpers/get-data-from-api/helpers/is-interrupted.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const Interrupter = require('../../../interrupter')
+
+module.exports = (interrupter) => {
+  return (
+    interrupter instanceof Interrupter &&
+    interrupter.hasInterrupted()
+  )
+}

--- a/workers/loc.api/helpers/get-data-from-api/index.js
+++ b/workers/loc.api/helpers/get-data-from-api/index.js
@@ -90,8 +90,7 @@ module.exports = (
           startingDelayMs: 80_000,
           maxDelayMs: 5 * 60 * 1_000,
           ...backOffOpts,
-          prevBackOffDelayMs,
-          numOfDelayedAttempts: countRateLimitError
+          prevBackOffDelayMs
         })
         prevBackOffDelayMs = delayMs
         const { isInterrupted } = await delay(delayMs, _interrupter)

--- a/workers/loc.api/helpers/get-data-from-api/index.js
+++ b/workers/loc.api/helpers/get-data-from-api/index.js
@@ -93,7 +93,7 @@ module.exports = (
           prevBackOffDelayMs,
           numOfDelayedAttempts: countRateLimitError
         })
-        prevBackOffDelayMs = delay
+        prevBackOffDelayMs = delayMs
         const { isInterrupted } = await delay(delayMs, _interrupter)
 
         if (isInterrupted) {


### PR DESCRIPTION
This PR adds exponential backoff and jitter for bfx-api requests to improve `Rate Limit` bypassing

---

Here we implement `Decorrelated Jitter` described in AWS article https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/ And add a small improvement to shift the starting point of jitter for each iteration. In practice, it helps better to move through the `Rate Limit` for the Sync and Tax Report
