### PR TITLE
Add network to tether ccy for movement export

### DIFF
--- a/test/5-queue-load.spec.js
+++ b/test/5-queue-load.spec.js
@@ -47,7 +47,14 @@ describe('Queue load', () => {
 
     mockRESTv2Srv = createMockRESTv2SrvWithDate(start, end, null, {
       ledgers: { limit },
-      user_info: null
+      user_info: null,
+      symbols: null,
+      map_symbols: null,
+      inactive_currencies: null,
+      margin_currencies: null,
+      inactive_symbols: null,
+      futures: null,
+      currencies: null
     })
 
     await rmAllFiles(tempDirPath)

--- a/workers/loc.api/generate-report-file/report.file.job.data.js
+++ b/workers/loc.api/generate-report-file/report.file.job.data.js
@@ -894,7 +894,8 @@ class ReportFileJobData {
         note: 'NOTE'
       },
       formatSettings: {
-        mtsUpdated: 'date'
+        mtsUpdated: 'date',
+        currency: 'prepareCurrency'
       }
     }
 

--- a/workers/loc.api/queue/write-data-to-stream/helpers.js
+++ b/workers/loc.api/queue/write-data-to-stream/helpers.js
@@ -15,15 +15,16 @@ const _validTxtTimeZone = (val, timezone, format) => {
 
 const _formatters = {
   prepareCurrency: (ccy, params) => {
-    const currencies = params?.symbols?.currencies
     const currencyName = params?.allDataFields?.currencyName
+    const currencyNameMap = params?.symbols?.currencyNameMap
 
     if (
       !ccy ||
       typeof ccy !== 'string' ||
-      !Array.isArray(currencies) ||
       !currencyName ||
-      typeof currencyName !== 'string'
+      typeof currencyName !== 'string' ||
+      !currencyNameMap ||
+      typeof currencyNameMap !== 'object'
     ) {
       return ccy
     }
@@ -35,7 +36,7 @@ const _formatters = {
     }
 
     const ccyId = currencyName.replace('TETHER', '')
-    const name = currencies.find((item) => item?.name === ccyId)
+    const name = currencyNameMap[ccyId]
 
     return name ?? ccy
   },

--- a/workers/loc.api/queue/write-data-to-stream/helpers.js
+++ b/workers/loc.api/queue/write-data-to-stream/helpers.js
@@ -14,6 +14,31 @@ const _validTxtTimeZone = (val, timezone, format) => {
 }
 
 const _formatters = {
+  prepareCurrency: (ccy, params) => {
+    const currencies = params?.symbols?.currencies
+    const currencyName = params?.allDataFields?.currencyName
+
+    if (
+      !ccy ||
+      typeof ccy !== 'string' ||
+      !Array.isArray(currencies) ||
+      !currencyName ||
+      typeof currencyName !== 'string'
+    ) {
+      return ccy
+    }
+    if (
+      ccy !== 'USDt' &&
+      ccy !== 'UST'
+    ) {
+      return ccy
+    }
+
+    const ccyId = currencyName.replace('TETHER', '')
+    const name = currencies.find((item) => item?.name === ccyId)
+
+    return name ?? ccy
+  },
   date: (
     val,
     {
@@ -112,6 +137,11 @@ const _dataFormatter = (data, formatSettings, params) => {
   const objArr = isArray ? clonedData : [clonedData]
 
   for (const obj of objArr) {
+    const formatterParams = {
+      ...params,
+      allDataFields: obj
+    }
+
     for (const [key, val] of Object.entries(formatSettings)) {
       try {
         if (
@@ -119,7 +149,7 @@ const _dataFormatter = (data, formatSettings, params) => {
           val &&
           typeof val === 'object'
         ) {
-          obj[key] = _dataFormatter(obj[key], val, params)
+          obj[key] = _dataFormatter(obj[key], val, formatterParams)
 
           continue
         }
@@ -127,7 +157,7 @@ const _dataFormatter = (data, formatSettings, params) => {
           typeof obj[key] !== 'undefined' &&
           typeof _formatters[val] === 'function'
         ) {
-          obj[key] = _formatters[val](obj[key], params)
+          obj[key] = _formatters[val](obj[key], formatterParams)
 
           continue
         }

--- a/workers/loc.api/queue/write-data-to-stream/index.js
+++ b/workers/loc.api/queue/write-data-to-stream/index.js
@@ -45,6 +45,13 @@ module.exports = (
   const currIterationArgs = cloneDeep(_args)
 
   const getData = rService[method].bind(rService)
+  const getSymbols = rService.getSymbols.bind(rService)
+  const symbols = await getDataFromApi({
+    getSymbols,
+    args: {},
+    callerName: 'REPORT_FILE_WRITER',
+    shouldNotInterrupt: true
+  })
 
   let count = 0
   let serialRequestsCount = 0
@@ -101,7 +108,7 @@ module.exports = (
         res,
         stream,
         formatSettings,
-        { ..._args.params },
+        { ..._args.params, symbols },
         method
       )
       processorQueue.emit('progress', 100)
@@ -142,7 +149,7 @@ module.exports = (
       res,
       stream,
       formatSettings,
-      { ..._args.params },
+      { ..._args.params, symbols },
       method
     )
 

--- a/workers/loc.api/queue/write-data-to-stream/index.js
+++ b/workers/loc.api/queue/write-data-to-stream/index.js
@@ -46,12 +46,17 @@ module.exports = (
 
   const getData = rService[method].bind(rService)
   const getSymbols = rService.getSymbols.bind(rService)
-  const symbols = await getDataFromApi({
-    getSymbols,
+  const symbols = (await getDataFromApi({
+    getData: getSymbols,
     args: {},
     callerName: 'REPORT_FILE_WRITER',
     shouldNotInterrupt: true
-  })
+  })) ?? {}
+  symbols.currencyNameMap = symbols.currencies.reduce((accum, curr) => {
+    accum[curr?.id] = curr?.name
+
+    return accum
+  }, {})
 
   let count = 0
   let serialRequestsCount = 0


### PR DESCRIPTION
This PR adds network to `tether` ccy for movement export similar to the UI representation. Adds a similar approach as on the UI side

---

UI layout:
<img width="720" height="225" alt="image (6)" src="https://github.com/user-attachments/assets/4ab8348a-a994-4bae-96ed-078126bc506e" />

Report export example:
<img width="774" height="113" alt="Screenshot from 2025-08-29 11-38-47" src="https://github.com/user-attachments/assets/193bf29d-fcd0-4e3c-8570-7f023c4ba1ca" />

