### PR TITLE
Fix file descriptor consumption issue

### DIFF
--- a/workers/loc.api/generate-report-file/csv-writer/helpers/index.js
+++ b/workers/loc.api/generate-report-file/csv-writer/helpers/index.js
@@ -1,7 +1,10 @@
 'use strict'
 
-const { pipeline } = require('stream/promises')
 const { stringify } = require('csv')
+
+const {
+  pipelineStreams
+} = require('../../../helpers')
 
 const streamWriterToOne = async (
   rStream,
@@ -10,7 +13,7 @@ const streamWriterToOne = async (
   opts
 ) => {
   const { end = true } = opts ?? {}
-  const promise = pipeline(rStream, wStream, { end })
+  const promise = pipelineStreams(rStream, wStream, { end })
 
   writeFn(rStream)
   rStream.end()

--- a/workers/loc.api/helpers/index.js
+++ b/workers/loc.api/helpers/index.js
@@ -64,6 +64,7 @@ const getDataFromApi = require('./get-data-from-api')
 const splitSymbolPairs = require('./split-symbol-pairs')
 const FOREX_SYMBS = require('./forex.symbs')
 const getTranslator = require('./get-translator')
+const pipelineStreams = require('./pipeline-streams')
 
 module.exports = {
   getREST,
@@ -115,5 +116,6 @@ module.exports = {
   parsePositionsAuditId,
   splitSymbolPairs,
   FOREX_SYMBS,
-  getTranslator
+  getTranslator,
+  pipelineStreams
 }

--- a/workers/loc.api/helpers/pipeline-streams.js
+++ b/workers/loc.api/helpers/pipeline-streams.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const { pipeline } = require('node:stream/promises')
+
+module.exports = async (stringifier, writable, opts) => {
+  try {
+    const end = opts?.end ?? true
+
+    await pipeline(stringifier, writable, { end })
+  } catch (err) {
+    /*
+     * If an error occurs, eg when receiving data from the BFX API,
+     * a recording may occur after destruction in the stream
+     */
+    if (
+      err.code === 'ERR_STREAM_DESTROYED' ||
+      err.code === 'ERR_STREAM_PREMATURE_CLOSE'
+    ) {
+      return
+    }
+
+    throw err
+  }
+}

--- a/workers/loc.api/queue/aggregator.js
+++ b/workers/loc.api/queue/aggregator.js
@@ -18,6 +18,8 @@ module.exports = (
   sendMail
 ) => {
   return async (job) => {
+    const streamSet = new Set()
+
     try {
       const {
         chunkCommonFolders,
@@ -50,7 +52,8 @@ module.exports = (
           {
             ...userInfo,
             email
-          }
+          },
+          streamSet
         )
 
         await sendMail(
@@ -128,6 +131,11 @@ module.exports = (
       }
 
       aggregatorQueue.emit('error:base', err, job)
+    } finally {
+      for (const stream of streamSet) {
+        stream.destroy()
+        streamSet.delete(stream)
+      }
     }
   }
 }

--- a/workers/loc.api/queue/helpers/index.js
+++ b/workers/loc.api/queue/helpers/index.js
@@ -3,7 +3,6 @@
 const getCompleteFileName = require('./get-complete-file-name')
 const {
   moveFileToLocalStorage,
-  writableToPromise,
   createUniqueFileName
 } = require('./utils')
 const getLocalReportFolderPaths = require(
@@ -14,7 +13,6 @@ const getReportContentType = require('./get-report-content-type')
 
 module.exports = {
   moveFileToLocalStorage,
-  writableToPromise,
   createUniqueFileName,
   getCompleteFileName,
   getLocalReportFolderPaths,

--- a/workers/loc.api/queue/helpers/utils.js
+++ b/workers/loc.api/queue/helpers/utils.js
@@ -160,19 +160,7 @@ const createUniqueFileName = async (rootPath, params, count = 0) => {
   return path.join(tempReportFolderPath, uniqueFileName)
 }
 
-const writableToPromise = stream => {
-  return new Promise((resolve, reject) => {
-    stream.once('finish', () => {
-      resolve('finish')
-    })
-    stream.once('error', err => {
-      reject(err)
-    })
-  })
-}
-
 module.exports = {
   moveFileToLocalStorage,
-  writableToPromise,
   createUniqueFileName
 }

--- a/workers/loc.api/queue/processor.js
+++ b/workers/loc.api/queue/processor.js
@@ -4,35 +4,18 @@ const {
   omit,
   cloneDeep
 } = require('lib-js-util-base')
-const { pipeline } = require('node:stream/promises')
 const { createWriteStream } = require('node:fs')
 const { unlink } = require('node:fs/promises')
 const { stringify } = require('csv')
 
 const {
+  pipelineStreams
+} = require('../helpers')
+const {
   createUniqueFileName
 } = require('./helpers')
 
 const { isAuthError } = require('../helpers')
-
-const pipelineStreams = async (stringifier, writable) => {
-  try {
-    await pipeline(stringifier, writable)
-  } catch (err) {
-    /*
-     * If an error occurs, eg when receiving data from the BFX API,
-     * a recording may occur after destruction in the stream
-     */
-    if (
-      err.code === 'ERR_STREAM_DESTROYED' ||
-      err.code === 'ERR_STREAM_PREMATURE_CLOSE'
-    ) {
-      return
-    }
-
-    throw err
-  }
-}
 
 const processReportFile = async (deps, args) => {
   const {

--- a/workers/loc.api/queue/upload-to-s3/index.js
+++ b/workers/loc.api/queue/upload-to-s3/index.js
@@ -69,7 +69,8 @@ module.exports = (
     queueName,
     subParamsArr,
     isSignatureRequired,
-    userInfo
+    userInfo,
+    streamSet
   ) => {
     const isMultiExport = (
       queueName === 'getMultiple' ||
@@ -92,8 +93,11 @@ module.exports = (
     const isSignReq = isSignatureRequired && isUppedPGPService
 
     const streams = filePaths.map((filePath, i) => {
+      const stream = fs.createReadStream(filePath)
+      streamSet.add(stream)
+
       return {
-        stream: fs.createReadStream(filePath),
+        stream,
         data: {
           name: getCompleteFileName(
             subParamsArr[i].name,

--- a/workers/loc.api/queue/write-data-to-stream/helpers.js
+++ b/workers/loc.api/queue/write-data-to-stream/helpers.js
@@ -184,6 +184,10 @@ const write = (
     const _item = dataNormalizer(item, method, params)
     const res = _dataFormatter(_item, formatSettings, params)
 
+    if (!stream.writable) {
+      return
+    }
+
     stream.write(res)
   }
 }

--- a/workers/loc.api/queue/write-data-to-stream/index.js
+++ b/workers/loc.api/queue/write-data-to-stream/index.js
@@ -58,12 +58,12 @@ module.exports = (
     return accum
   }, {})
 
+  processorQueue.emit('progress', 0)
+
   let count = 0
   let serialRequestsCount = 0
 
   while (true) {
-    processorQueue.emit('progress', 0)
-
     const _res = await getDataFromApi({
       getData,
       args: currIterationArgs,


### PR DESCRIPTION
This PR fixes file descriptor consumption issue to prevent leaks and reaching the allocated limit of descriptors for each process

---

How to debug and reproduce the issue:
- launch 10 instances of the report worker using `pm2`
  ```js
  const DEV_ENV = 'development'
  const PORT = 1337
  
  module.exports = {
    apps: [
      ...new Array(10)
        .fill({
          name: 'bfx-report',
          script: './worker.js',
          exec_mode: 'fork',
          time: true,
          env: {
            NODE_ENV: DEV_ENV
          }
        })
        .map((item, i) => {
          return {
            ...item,
            args: `--env=${DEV_ENV} --wtype=wrk-report-service-api --apiPort=${PORT + i} --dbId ${1 + i}`
          }
        })
    ]
  }
  ```
- check fd consumption for the cold run:
  ```sh
  #!/bin/bash
  
  set -euo pipefail
  
  while read name pid; \
  do \
    printf '%s[%5d]: %4d open fd(s)\n' "${name}" "$(< "${pid}")" "$(wc --lines < <(find "/proc/$(< "${pid}")/fd"))"; \
  done < <( \
    jq --raw-output '.[].pm2_env | select(.name | startswith("bfx-report")) | .name + " " + .pm_pid_path' < <( \
      pm2 jlist \
    ) \
  )
  ```
  <img width="527" height="206" alt="Screenshot from 2026-01-29 12-35-27" src="https://github.com/user-attachments/assets/51a7ba23-22b0-4c72-b804-c21e2a355757" />

- generate some csv files for the ledgers
- the above command ensures that, in normal mode, file descriptors are released after all files are generated
  <img width="527" height="206" alt="Screenshot from 2026-01-29 12-35-27" src="https://github.com/user-attachments/assets/51a7ba23-22b0-4c72-b804-c21e2a355757" />

- allow 2 iterations of data fetching to write to csv file and then throw a `new Error('ERR_TEST_BFX_API_ISSUE')` to simulate fetching data issue https://github.com/bitfinexcom/bfx-report/blob/master/workers/loc.api/queue/write-data-to-stream/index.js#L67
- re-run all worker instances
- generate some csv files for the ledgers
- and here we go, we can see fd consumption
  <img width="527" height="206" alt="Screenshot from 2026-01-29 09-44-40" src="https://github.com/user-attachments/assets/5a4aa084-f305-4fad-9498-6b6b3c13085c" />

- it's necessary to destroy streams in case error
