### PR TITLE
Fix node-fetch timeout handling

### DIFF
--- a/workers/loc.api/helpers/api-errors-testers.js
+++ b/workers/loc.api/helpers/api-errors-testers.js
@@ -39,8 +39,13 @@ const isETimedOutError = (err) => {
   return /ETIMEDOUT/i.test(_getErrorString(err))
 }
 
+/**
+ * https://github.com/node-fetch/node-fetch/blob/v2.6.9/src/index.js#L81
+ * https://github.com/node-fetch/node-fetch/blob/v3.3.2/src/index.js#L70
+ * https://github.com/node-fetch/node-fetch/blob/v2.6.9/src/body.js#L228
+ */
 const isNodeFetchTimeoutError = (err) => {
-  return /timeout/i.test(_getErrorString(err))
+  return /(Response timeout while trying to fetch)|(The user aborted a request)|(The operation was aborted)/i.test(_getErrorString(err))
 }
 
 const isEAiAgainError = (err) => {


### PR DESCRIPTION
This PR fixes `node-fetch` timeout handling

---

Basic changes:
- Fixes `node-fetch` timeout handling to prevent side effects when handling errors where we can have `setTimeout` in the stack trace. Uses `Response timeout while trying to fetch` for detection, `node-fetch` `v2`: https://github.com/node-fetch/node-fetch/blob/v2.6.9/src/body.js#L228
- Adds compatibility with `AbortController` being added in this PR: https://github.com/bitfinexcom/bfx-api-node-rest/pull/114, for `node-fetch` `v2` we should use `The user aborted a request` https://github.com/node-fetch/node-fetch/blob/v2.6.9/src/index.js#L81
- Adds support for a future update to `node-fetch` `v3` where the `timeout` opt was removed totally, and uses only `AbortController`, should use `The operation was aborted` https://github.com/node-fetch/node-fetch/blob/v3.3.2/src/index.js#L70