### PR TITLE
Fix cyclic unauth error when generating csv

### DIFF
--- a/workers/loc.api/di/app.deps.js
+++ b/workers/loc.api/di/app.deps.js
@@ -185,7 +185,8 @@ module.exports = ({
           TYPES.ProcessorQueue,
           TYPES.AggregatorQueue,
           TYPES.WriteDataToStream,
-          TYPES.PdfWriter
+          TYPES.PdfWriter,
+          TYPES.I18next
         ]
       ))
     bind(TYPES.Aggregator).toConstantValue(

--- a/workers/loc.api/queue/processor.js
+++ b/workers/loc.api/queue/processor.js
@@ -21,10 +21,11 @@ const processReportFile = async (deps, args) => {
   const {
     data,
     filePath,
-    streamSet
+    streamSet,
+    isUnauth
   } = args
 
-  const write = data?.isUnauth
+  const write = isUnauth
     ? 'Your file could not be completed, please try again'
     : data
 
@@ -37,7 +38,7 @@ const processReportFile = async (deps, args) => {
         jobData: data,
         pdfCustomTemplateName: data?.pdfCustomTemplateName,
         language: data?.args?.params.language,
-        isError: data?.isUnauth
+        isError: isUnauth
       })
     streamSet.add(pdfStream)
 
@@ -164,7 +165,8 @@ module.exports = (
           {
             data,
             filePath,
-            streamSet
+            streamSet,
+            isUnauth
           }
         )
       }
@@ -190,12 +192,14 @@ module.exports = (
         processorQueue.emit('error:unlink', job)
       }
 
-      job.done(err)
-
       if (isAuthError(err)) {
+        job.done()
         processorQueue.emit('error:auth', job)
+
+        return
       }
 
+      job.done(err)
       processorQueue.emit('error:base', err, job)
     } finally {
       for (const stream of streamSet) {

--- a/workers/loc.api/queue/processor.js
+++ b/workers/loc.api/queue/processor.js
@@ -15,7 +15,13 @@ const {
   createUniqueFileName
 } = require('./helpers')
 
-const { isAuthError } = require('../helpers')
+const {
+  isAuthError,
+  getTranslator
+} = require('../helpers')
+const TRANSLATION_NAMESPACES = require(
+  '../i18next/translation.namespaces'
+)
 
 const processReportFile = async (deps, args) => {
   const {
@@ -25,8 +31,20 @@ const processReportFile = async (deps, args) => {
     isUnauth
   } = args
 
+  const language = data?.args?.params?.language
+  const translate = getTranslator(
+    { i18next: deps.i18next },
+    {
+      lng: language,
+      ns: TRANSLATION_NAMESPACES.PDF
+    }
+  )
+  const defaultUnauthMsg = 'Your file could not be completed, please try again'
+  const unauthMsg = translate(defaultUnauthMsg, {
+    prop: 'template.errorMessage'
+  })
   const write = isUnauth
-    ? 'Your file could not be completed, please try again'
+    ? unauthMsg
     : data
 
   const writable = createWriteStream(filePath)
@@ -37,7 +55,7 @@ const processReportFile = async (deps, args) => {
       .createPDFStream({
         jobData: data,
         pdfCustomTemplateName: data?.pdfCustomTemplateName,
-        language: data?.args?.params.language,
+        language,
         isError: isUnauth
       })
     streamSet.add(pdfStream)
@@ -86,7 +104,8 @@ module.exports = (
   processorQueue,
   aggregatorQueue,
   writeDataToStream,
-  pdfWriter
+  pdfWriter,
+  i18next
 ) => {
   processorQueue.on('completed', (result) => {
     aggregatorQueue.addJob({
@@ -160,7 +179,8 @@ module.exports = (
         await processReportFile(
           {
             writeDataToStream,
-            pdfWriter
+            pdfWriter,
+            i18next
           },
           {
             data,

--- a/workers/loc.api/queue/write-data-to-stream/auth-token-manager.js
+++ b/workers/loc.api/queue/write-data-to-stream/auth-token-manager.js
@@ -49,6 +49,41 @@ const regenerateAuthToken = async (auth, deps) => {
   }
 }
 
+const invalidateAuthToken = async (auth, deps) => {
+  const { authToken } = auth ?? {}
+
+  if (
+    !authToken ||
+    typeof authToken !== 'string'
+  ) {
+    return
+  }
+
+  const {
+    rService,
+    getDataFromApi
+  } = deps ?? {}
+
+  try {
+    await getDataFromApi({
+      getData: (s, args) => rService._invalidateAuthToken(args),
+      args: { auth, params: { authToken } },
+      callerName: 'REPORT_FILE_WRITER',
+      eNetErrorAttemptsTimeframeMin: 10 / 60,
+      eNetErrorAttemptsTimeoutMs: 1000,
+      shouldNotInterrupt: true
+    })
+  } catch (err) {
+    throw new AuthError({
+      data: {
+        isAuthTokenInvalidationError: true,
+        rootMessage: err.toString()
+      }
+    })
+  }
+}
+
 module.exports = {
-  regenerateAuthToken
+  regenerateAuthToken,
+  invalidateAuthToken
 }

--- a/workers/loc.api/queue/write-data-to-stream/auth-token-manager.js
+++ b/workers/loc.api/queue/write-data-to-stream/auth-token-manager.js
@@ -19,7 +19,7 @@ const regenerateAuthToken = async (auth, deps) => {
 
   try {
     const opts = {
-      ttl: 24 * 60 * 60,
+      ttl: 60 * 60,
       writePermission: false
     }
 

--- a/workers/loc.api/queue/write-data-to-stream/auth-token-manager.js
+++ b/workers/loc.api/queue/write-data-to-stream/auth-token-manager.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const { AuthError } = require('../../errors')
+
+const regenerateAuthToken = async (auth, deps) => {
+  const { authToken } = auth ?? {}
+
+  if (
+    !authToken ||
+    typeof authToken !== 'string'
+  ) {
+    return auth
+  }
+
+  const {
+    rService,
+    getDataFromApi
+  } = deps ?? {}
+
+  try {
+    const opts = {
+      ttl: 24 * 60 * 60,
+      writePermission: false
+    }
+
+    const res = await getDataFromApi({
+      getData: (s, args) => rService._generateToken(args, opts),
+      args: { auth },
+      callerName: 'REPORT_FILE_WRITER',
+      eNetErrorAttemptsTimeframeMin: 10 / 60,
+      eNetErrorAttemptsTimeoutMs: 1000,
+      shouldNotInterrupt: true
+    })
+
+    const [authToken] = Array.isArray(res) ? res : [null]
+
+    if (!authToken) {
+      throw new AuthError()
+    }
+
+    return { authToken }
+  } catch (err) {
+    throw new AuthError({
+      data: {
+        isAuthTokenGenerationError: true,
+        rootMessage: err.toString()
+      }
+    })
+  }
+}
+
+module.exports = {
+  regenerateAuthToken
+}

--- a/workers/loc.api/queue/write-data-to-stream/index.js
+++ b/workers/loc.api/queue/write-data-to-stream/index.js
@@ -13,7 +13,8 @@ const {
   progress
 } = require('./helpers')
 const {
-  regenerateAuthToken
+  regenerateAuthToken,
+  invalidateAuthToken
 } = require('./auth-token-manager')
 
 module.exports = (
@@ -186,4 +187,12 @@ module.exports = (
       currIterationArgs.params.end = lastItem[propName] - 1
     }
   }
+
+  await invalidateAuthToken(
+    auth,
+    {
+      rService,
+      getDataFromApi
+    }
+  )
 }

--- a/workers/loc.api/queue/write-data-to-stream/index.js
+++ b/workers/loc.api/queue/write-data-to-stream/index.js
@@ -12,6 +12,9 @@ const {
   write,
   progress
 } = require('./helpers')
+const {
+  regenerateAuthToken
+} = require('./auth-token-manager')
 
 module.exports = (
   rService,
@@ -36,8 +39,15 @@ module.exports = (
   const propName = jobData.propNameForPagination
   const formatSettings = jobData.formatSettings
 
+  const auth = await regenerateAuthToken(
+    jobData?.args?.auth,
+    {
+      rService,
+      getDataFromApi
+    }
+  )
   const _args = {
-    auth: { ...jobData?.args?.auth },
+    auth,
     params: omitExtraParamFieldsForReportExport(jobData?.args?.params)
   }
 
@@ -48,7 +58,7 @@ module.exports = (
   const getSymbols = rService.getSymbols.bind(rService)
   const symbols = (await getDataFromApi({
     getData: getSymbols,
-    args: { auth: { ...jobData?.args?.auth } },
+    args: { auth },
     callerName: 'REPORT_FILE_WRITER',
     shouldNotInterrupt: true
   })) ?? {}


### PR DESCRIPTION
This PR fixes cyclic unauth error for `authToken` when generating csv

---

The main issue is the use of a short-lived token from the UI and the fact that report file generation can be requested at the very end of the token's lifecycle
Solution:
- if the sent token from the UI is valid
- generate a new token with a TTL of 24h
- use the new token for report generation
- invalidate this token after report generation is complete

Also fixes: if report file generation is requested at the very end of the token's lifecycle and the token becomes invalid before file generation is complete, prevent the cyclical restart of generation and notify the user accordingly
