### PR TITLE
Add weighted-average-report export to pdf file for consistency

### DIFF
--- a/test/test-cases/report-file-generations.js
+++ b/test/test-cases/report-file-generations.js
@@ -777,11 +777,6 @@ module.exports = (
   it('it should be successfully performed by the getWeightedAveragesReportFile method', async function () {
     this.timeout(60000)
 
-    // TODO: Wait for implementation of pdf template in the next release
-    if (isPDFRequired) {
-      this.skip()
-    }
-
     const procPromise = queueToPromise(params.processorQueue)
     const aggrPromise = queueToPromise(params.aggregatorQueue)
 

--- a/workers/loc.api/generate-report-file/pdf-writer/template-file-names.js
+++ b/workers/loc.api/generate-report-file/pdf-writer/template-file-names.js
@@ -1,5 +1,6 @@
 'use strict'
 
 module.exports = {
-  MAIN: 'main.pug'
+  MAIN: 'main.pug',
+  WEIGHTED_AVERAGES_REPORT: 'weighted-averages-report.pug'
 }

--- a/workers/loc.api/generate-report-file/pdf-writer/templates/style.css
+++ b/workers/loc.api/generate-report-file/pdf-writer/templates/style.css
@@ -54,28 +54,32 @@ html, body, .header, .footer {
   font-size: 11px;
 }
 
-h1 {
+h1, .h1 {
   font-size: 16px;
 }
 
-h2 {
+h2, .h2 {
   font-size: 14px;
 }
 
-h3 {
+h3, .h3 {
   font-size: 12px;
 }
 
-h4 {
+h4, .h4 {
   font-size: 11px;
 }
 
-h5 {
+h5, .h5 {
   font-size: 10px;
 }
 
-h6 {
+h6, .h6 {
   font-size: 9px;
+}
+
+h7, .h7 {
+  font-size: 8px;
 }
 
 .footer {

--- a/workers/loc.api/generate-report-file/pdf-writer/templates/weighted-averages-report.pug
+++ b/workers/loc.api/generate-report-file/pdf-writer/templates/weighted-averages-report.pug
@@ -3,9 +3,17 @@ extends base.pug
 block commonHeader
   - const data = Array.isArray(apiData) ? apiData : [{}]
   - const columns = reportColumns ?? Object.keys(data?.[0] ?? {})
+  - const columnArr = Array.isArray(columns) ? [...columns] : Object.keys(columns)
+  - const topColumns = columnArr.fill('')
+  - topColumns[1] = 'Buy'
+  - topColumns[4] = 'Sell'
+  - topColumns[7] = 'Cumulative'
 
   .content
     ul.responsive-table
+      li.table-header
+        each columnVal, columnKey in topColumns
+          .col #{columnVal}
       li.table-header
         each columnVal, columnKey in columns
           .col #{columnVal}

--- a/workers/loc.api/generate-report-file/pdf-writer/templates/weighted-averages-report.pug
+++ b/workers/loc.api/generate-report-file/pdf-writer/templates/weighted-averages-report.pug
@@ -1,7 +1,7 @@
 extends base.pug
 
 block commonHeader
-  - const data = Array.isArray(apiData?.res) ? apiData.res : [{}]
+  - const data = Array.isArray(apiData) ? apiData : [{}]
   - const columns = reportColumns ?? Object.keys(data?.[0] ?? {})
 
   .content
@@ -11,7 +11,7 @@ block commonHeader
           .col #{columnVal}
 
 block content
-  - const data = Array.isArray(apiData?.res) ? apiData.res : [{}]
+  - const data = Array.isArray(apiData) ? apiData : [{}]
   - const columns = reportColumns ?? Object.keys(data?.[0] ?? {})
 
   ul.responsive-table

--- a/workers/loc.api/generate-report-file/pdf-writer/templates/weighted-averages-report.pug
+++ b/workers/loc.api/generate-report-file/pdf-writer/templates/weighted-averages-report.pug
@@ -1,0 +1,21 @@
+extends base.pug
+
+block commonHeader
+  - const data = Array.isArray(apiData?.res) ? apiData.res : [{}]
+  - const columns = reportColumns ?? Object.keys(data?.[0] ?? {})
+
+  .content
+    ul.responsive-table
+      li.table-header
+        each columnVal, columnKey in columns
+          .col #{columnVal}
+
+block content
+  - const data = Array.isArray(apiData?.res) ? apiData.res : [{}]
+  - const columns = reportColumns ?? Object.keys(data?.[0] ?? {})
+
+  ul.responsive-table
+    each dataItem, dataIndex in data
+      li.table-row
+        each columnVal, columnKey in columns
+          .col #{dataItem[columnKey]}

--- a/workers/loc.api/generate-report-file/pdf-writer/templates/weighted-averages-report.pug
+++ b/workers/loc.api/generate-report-file/pdf-writer/templates/weighted-averages-report.pug
@@ -10,7 +10,7 @@ block commonHeader
   - topColumns[7] = 'Cumulative'
 
   .content
-    ul.responsive-table
+    ul.responsive-table.h7
       li.table-header
         each columnVal, columnKey in topColumns
           .col #{columnVal}
@@ -22,7 +22,7 @@ block content
   - const data = Array.isArray(apiData) ? apiData : [{}]
   - const columns = reportColumns ?? Object.keys(data?.[0] ?? {})
 
-  ul.responsive-table
+  ul.responsive-table.h7
     each dataItem, dataIndex in data
       li.table-row
         each columnVal, columnKey in columns

--- a/workers/loc.api/generate-report-file/report.file.job.data.js
+++ b/workers/loc.api/generate-report-file/report.file.job.data.js
@@ -14,6 +14,7 @@ const {
   FindMethodToGetReportFileError,
   SymbolsTypeError
 } = require('../errors')
+const TEMPLATE_FILE_NAMES = require('./pdf-writer/template-file-names')
 
 const depsTypes = (TYPES) => [
   TYPES.RService,
@@ -1234,7 +1235,8 @@ class ReportFileJobData {
         firstTradeMts: 'date',
         lastTradeMts: 'date'
       },
-      csvCustomWriter: this.weightedAveragesReportCsvWriter
+      csvCustomWriter: this.weightedAveragesReportCsvWriter,
+      pdfCustomTemplateName: TEMPLATE_FILE_NAMES.WEIGHTED_AVERAGES_REPORT
     }
 
     return jobData


### PR DESCRIPTION
This PR adds `weighted-average-report` export to PDF file for consistency with other report exports. Also, prevents skipping weighted-averages-report export test for pdf as it was added some time ago

---

Example of how it looks in CSV right now
<img width="1347" height="133" alt="Screenshot from 2026-06-24 12-55-59" src="https://github.com/user-attachments/assets/c8a92662-1f07-4e5f-9537-3e3ad05d523b" />

Example of how it will look in PDF
<img width="963" height="363" alt="Screenshot from 2026-06-24 12-54-39" src="https://github.com/user-attachments/assets/72c700a8-5d7c-4567-aa7d-8379e018da47" />
