### PR TITLE
Add more efficient way to filter ledgers by wallet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "ajv": "8.18.0",
         "ajv-formats": "3.0.1",
         "async": "3.2.4",
-        "bitfinex-api-node": "9.0.0",
+        "bitfinex-api-node": "9.1.0",
         "colors": "1.4.0",
         "csv": "5.5.3",
         "i18next": "23.15.1",
@@ -722,7 +722,8 @@
     "node_modules/after-all-results": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/after-all-results/-/after-all-results-2.0.0.tgz",
-      "integrity": "sha512-2zHEyuhSJOuCrmas9YV0YL/MFCWLxe1dS6k/ENhgYrb/JqyMnadLN4iIAc9kkZrbElMDyyAGH/0J18OPErOWLg=="
+      "integrity": "sha512-2zHEyuhSJOuCrmas9YV0YL/MFCWLxe1dS6k/ENhgYrb/JqyMnadLN4iIAc9kkZrbElMDyyAGH/0J18OPErOWLg==",
+      "license": "MIT"
     },
     "node_modules/ajv": {
       "version": "8.18.0",
@@ -1093,6 +1094,7 @@
       "resolved": "https://registry.npmjs.org/async-cache/-/async-cache-1.1.0.tgz",
       "integrity": "sha512-YDQc4vBn5NFhY6g6HhVshyi3Fy9+SQ5ePnE7JLDJn1DoL+i7ER+vMwtTNOYk9leZkYMnOwpBCWqyLDPw8Aig8g==",
       "deprecated": "No longer maintained. Use [lru-cache](http://npm.im/lru-cache) version 7.6 or higher, and provide an asynchronous `fetchMethod` option.",
+      "license": "ISC",
       "dependencies": {
         "lru-cache": "^4.0.0"
       }
@@ -1228,9 +1230,10 @@
       }
     },
     "node_modules/bfx-api-node-models": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/bfx-api-node-models/-/bfx-api-node-models-2.1.1.tgz",
-      "integrity": "sha512-lgN1hooCsabrjPrDQe8JjmGMB8Uh95i7FQT4U06aebeXTyeLTghnygc5tVFKC2RumSPKnCJZ4eGwGA1E1SoRCw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bfx-api-node-models/-/bfx-api-node-models-2.1.2.tgz",
+      "integrity": "sha512-LVX5CDIpVJB7t62iOIAh7bGL6ovQBrTQeTHRNFNzYw1w8jXPZpeeh6S5Niv0NLRht1RVd9Vsv7sN1EUzWDB28w==",
+      "license": "MIT",
       "dependencies": {
         "bfx-api-node-util": "^1.0.10",
         "bfx-hf-util": "git+https://github.com/bitfinexcom/bfx-hf-util.git#v1.0.12",
@@ -1247,6 +1250,7 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
       "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1262,12 +1266,14 @@
     "node_modules/bfx-api-node-models/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
     },
     "node_modules/bfx-api-node-rest": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/bfx-api-node-rest/-/bfx-api-node-rest-8.0.0.tgz",
-      "integrity": "sha512-ukCW6CL92OIc8KDJ4d+QfaqHzIETfpBX7BbzV4j5lALVeaw+DUuerqnAbXidq5q4013ldG8aSpldKIYcDZCDKg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/bfx-api-node-rest/-/bfx-api-node-rest-8.1.0.tgz",
+      "integrity": "sha512-hTGVPTZUfSG8mA695p3HIXU7mDS0HU55zU2/a9XkMCdH/iVtdhvcr3+5KmzV5wc3vRZ2op+mdTrRCGSPraGU1w==",
+      "license": "MIT",
       "dependencies": {
         "bfx-api-node-models": "^2.0.0",
         "bfx-api-node-util": "^1.0.10",
@@ -1284,6 +1290,7 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
       "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1299,7 +1306,8 @@
     "node_modules/bfx-api-node-rest/node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
     },
     "node_modules/bfx-api-node-util": {
       "version": "1.0.12",
@@ -1404,12 +1412,13 @@
       }
     },
     "node_modules/bitfinex-api-node": {
-      "version": "9.0.0",
-      "resolved": "git+ssh://git@github.com/bitfinexcom/bitfinex-api-node.git#f6181cbe3d421548244f37af8045b0d37729c73f",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/bitfinex-api-node/-/bitfinex-api-node-9.1.0.tgz",
+      "integrity": "sha512-zBbrGZaVTXL5qv/5DVWoMyVu+bS8ZuLulIVXzE9nozoG3b2MkfozzFyloSOOwHeEJ0hTuWqFfKKlX6ldAXTkPQ==",
       "license": "MIT",
       "dependencies": {
         "bfx-api-node-models": "^2.0.0",
-        "bfx-api-node-rest": "^8.0.0",
+        "bfx-api-node-rest": "^8.1.0",
         "bfx-api-node-util": "^1.0.12",
         "bfx-api-node-ws1": "^1.0.0",
         "bignumber.js": "9.0.0",
@@ -1497,7 +1506,8 @@
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "1.20.4",
@@ -2239,6 +2249,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
       "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "exit-on-epipe": "~1.0.1",
         "printj": "~1.1.0"
@@ -2524,6 +2535,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/dirty-chai/-/dirty-chai-2.0.1.tgz",
       "integrity": "sha512-ys79pWKvDMowIDEPC6Fig8d5THiC0DJ2gmTeGzVAoEH18J8OzLud0Jh7I9IWg3NSk8x2UocznUuFmfHCXYZx9w==",
+      "license": "MIT",
       "peerDependencies": {
         "chai": ">=2.2.1 <5"
       }
@@ -2622,6 +2634,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/error-callsites/-/error-callsites-2.0.4.tgz",
       "integrity": "sha512-V877Ch4FC4FN178fDK1fsrHN4I1YQIBdtjKrHh3BUHMnh3SMvwUVrqkaOgDpUuevgSNna0RBq6Ox9SGlxYrigA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.x"
       }
@@ -3411,6 +3424,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
       "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8"
       }
@@ -4414,6 +4428,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
       "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==",
+      "license": "ISC",
       "bin": {
         "in-install": "in-install.js",
         "in-publish": "in-publish.js",
@@ -5226,6 +5241,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/load-source-map/-/load-source-map-1.0.0.tgz",
       "integrity": "sha512-U69swlFKzCLHTWBBrN+Skou49GPVn9sg8JkngBFh1A/WzjOPaJ2lgtWSGh+457Qsg+r/gmHHFBwsSJQA7nI6sQ==",
+      "license": "MIT",
       "dependencies": {
         "in-publish": "^2.0.0",
         "semver": "^5.3.0",
@@ -5236,6 +5252,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -5411,6 +5428,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "license": "ISC",
       "dependencies": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -6361,6 +6379,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
       "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
+      "license": "Apache-2.0",
       "bin": {
         "printj": "bin/printj.njs"
       },
@@ -6418,7 +6437,8 @@
     "node_modules/pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
+      "license": "ISC"
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -7286,6 +7306,7 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7303,6 +7324,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/stackman/-/stackman-4.0.1.tgz",
       "integrity": "sha512-lntIge3BFEElgvpZT2ld5f4U+mF84fRtJ8vA3ymUVx1euVx43ZMkd09+5RWW4FmvYDFhZwPh1gvtdsdnJyF4Fg==",
+      "license": "MIT",
       "dependencies": {
         "after-all-results": "^2.0.0",
         "async-cache": "^1.1.0",
@@ -8285,7 +8307,8 @@
     "node_modules/yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
+      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.2.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ajv": "8.18.0",
     "ajv-formats": "3.0.1",
     "async": "3.2.4",
-    "bitfinex-api-node": "9.0.0",
+    "bitfinex-api-node": "9.1.0",
     "colors": "1.4.0",
     "csv": "5.5.3",
     "i18next": "23.15.1",

--- a/test/1-api.spec.js
+++ b/test/1-api.spec.js
@@ -778,6 +778,38 @@ describe('API', () => {
     ])
   })
 
+  it('it should be successfully performed by the getLedgers method filtered by wallet', async function () {
+    this.timeout(5000)
+
+    const res = await agent
+      .post(`${basePath}/json-rpc`)
+      .type('json')
+      .send({
+        auth,
+        method: 'getLedgers',
+        params: {
+          wallet: 'exchange',
+          start: 0,
+          end,
+          limit: 2
+        },
+        id: 5
+      })
+      .expect('Content-Type', /json/)
+      .expect(200)
+
+    assert.isObject(res.body)
+    assert.propertyVal(res.body, 'id', 5)
+    assert.isObject(res.body.result)
+    assert.isArray(res.body.result.res)
+    assert.isNumber(res.body.result.nextPage)
+
+    for (const resItem of res.body.result.res) {
+      assert.isObject(resItem)
+      assert.deepEqual(resItem.wallet, 'exchange')
+    }
+  })
+
   it('it should be successfully performed by the getLedgers method, without params', async function () {
     this.timeout(5000)
 

--- a/test/helpers/mock-data.js
+++ b/test/helpers/mock-data.js
@@ -209,7 +209,7 @@ module.exports = new Map([
     [[
       12345,
       'BTC',
-      null,
+      'exchange',
       _ms,
       null,
       -0.00001,

--- a/workers/loc.api/data-validator/schemas/defs.js
+++ b/workers/loc.api/data-validator/schemas/defs.js
@@ -152,6 +152,10 @@ module.exports = {
     candleTimeframe: {
       type: 'string',
       minLength: 2
+    },
+    wallet: {
+      type: 'string',
+      minLength: 1
     }
   }
 }

--- a/workers/loc.api/data-validator/schemas/getLedgersFileReq.js
+++ b/workers/loc.api/data-validator/schemas/getLedgersFileReq.js
@@ -19,6 +19,9 @@ module.exports = {
     symbol: {
       $ref: 'defs#/definitions/symbolWithMinItem'
     },
+    wallet: {
+      $ref: 'defs#/definitions/wallet'
+    },
     category: {
       type: ['string', 'integer'],
       if: {

--- a/workers/loc.api/data-validator/schemas/getLedgersReq.js
+++ b/workers/loc.api/data-validator/schemas/getLedgersReq.js
@@ -19,6 +19,9 @@ module.exports = {
     symbol: {
       $ref: 'defs#/definitions/symbolWithMinItem'
     },
+    wallet: {
+      $ref: 'defs#/definitions/wallet'
+    },
     category: {
       type: ['string', 'integer'],
       if: {

--- a/workers/loc.api/helpers/prepare-response/helpers/get-params-map.js
+++ b/workers/loc.api/helpers/prepare-response/helpers/get-params-map.js
@@ -27,7 +27,8 @@ const PARAMS_MAP = {
   ledgers: {
     ...MAIN_PARAMS_MAP,
     symbol: 'filters.ccy',
-    category: 'filters.category'
+    category: 'filters.category',
+    wallet: 'filters.wallet'
   },
   statusMessages: {
     type: 'type',


### PR DESCRIPTION
This PR adds more efficient way to filter ledgers by `wallet` as rest_v2_api supports it:
- https://docs.bitfinex.com/reference/rest-auth-ledgers

---

Request example:
```jsonc
{
  "auth": {
    "authToken": "user-token"
  },
  "method": "getLedgers",
  "params": {
    "start": 0,
    "end": 1779785952178,
    "wallet": "exchange"
  }
}
```

---

Depends on these PRs:
- https://github.com/bitfinexcom/bfx-api-node-rest/pull/115
- https://github.com/bitfinexcom/bitfinex-api-node/pull/597
